### PR TITLE
feat(styles): style certain keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,25 @@ logger.SetReportCaller(false)
 logger.SetLevel(log.DebugLevel)
 ```
 
+### Styles
+
+You can customize the logger styles using [Lipgloss][lipgloss]. The styles are
+defined at a global level in [styles.go](./styles.go).
+
+```go
+// Override the default error level style.
+log.ErrorLevelStyle = lipgloss.NewStyle().
+    SetString("ERROR!!").
+    Padding(0, 1, 0, 1).
+    Background(lipgloss.Color("204")).
+    Foreground(lipgloss.Color("0"))
+// Add a custom style for key `err`
+log.KeyStyles["err"] = lipgloss.NewStyle().Foreground(lipgloss.Color("204"))
+log.Error("Whoops!", "err", "kitchen on fire")
+```
+
+<img width="400" src="https://vhs.charm.sh/vhs-1s1qma0OVFeWFGqtBAPpfW.gif" alt="Made with VHS">
+
 ### Sub-logger
 
 Create sub-loggers with their specific fields.

--- a/examples/styles/styles.go
+++ b/examples/styles/styles.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/log"
+)
+
+func main() {
+	log.ErrorLevelStyle = lipgloss.NewStyle().
+		SetString("ERROR!!").
+		Padding(0, 1, 0, 1).
+		Background(lipgloss.Color("204")).
+		Foreground(lipgloss.Color("0"))
+	log.KeyStyles["err"] = lipgloss.NewStyle().Foreground(lipgloss.Color("204"))
+	logger := log.New()
+	logger.Error("Whoops!", "err", "kitchen on fire")
+	time.Sleep(3 * time.Second)
+}

--- a/examples/styles/styles.tape
+++ b/examples/styles/styles.tape
@@ -1,0 +1,8 @@
+Output styles.gif
+
+Set Height 250
+Set Width 700
+
+Type "./styles" Sleep 500ms Enter
+
+Sleep 3s

--- a/styles.go
+++ b/styles.go
@@ -73,6 +73,9 @@ var (
 			Light: "133",
 			Dark:  "134",
 		})
+
+	// KeyStyles overrides styles for specific keys.
+	KeyStyles = map[string]lipgloss.Style{}
 )
 
 // levelStyle is a helper function to get the style for a level.

--- a/text.go
+++ b/text.go
@@ -200,7 +200,11 @@ func (l *logger) textFormatter(keyvals ...interface{}) {
 				continue
 			}
 			if !l.noStyles {
-				key = KeyStyle.Render(key)
+				if keyStyle, ok := KeyStyles[key]; ok {
+					key = keyStyle.Render(key)
+				} else {
+					key = KeyStyle.Render(key)
+				}
 				val = ValueStyle.Render(val)
 			}
 


### PR DESCRIPTION
Add the ability to style certain keys

Fixes: https://github.com/charmbracelet/log/issues/14

Example:
```go
package main

import (
	"fmt"

	"github.com/charmbracelet/lipgloss"
	"github.com/charmbracelet/log"
)

func main() {
	log.KeyStyles["err"] = lipgloss.NewStyle().Foreground(lipgloss.Color("#ff0000"))
	err := fmt.Errorf("too much sugar")
	log.Error("failed to bake cookies", "err", err)
}

```