### PR TITLE
fix(text) escape value before rendering styles

### DIFF
--- a/text.go
+++ b/text.go
@@ -16,14 +16,14 @@ const (
 	indentSeparator = "  │ "
 )
 
-func writeIndent(w io.Writer, str string, indent string, newline bool) {
+func (l *logger) writeIndent(w io.Writer, str string, indent string, newline bool) {
 	// kindly borrowed from hclog
 	for {
 		nl := strings.IndexByte(str, '\n')
 		if nl == -1 {
 			if str != "" {
 				_, _ = w.Write([]byte(indent))
-				writeEscapedForOutput(w, str, false)
+				l.writeEscapedForOutput(w, str, false)
 				if newline {
 					_, _ = w.Write([]byte{'\n'})
 				}
@@ -32,7 +32,7 @@ func writeIndent(w io.Writer, str string, indent string, newline bool) {
 		}
 
 		_, _ = w.Write([]byte(indent))
-		writeEscapedForOutput(w, str[:nl], false)
+		l.writeEscapedForOutput(w, str[:nl], false)
 		_, _ = w.Write([]byte{'\n'})
 		str = str[nl+1:]
 	}
@@ -58,9 +58,12 @@ var bufPool = sync.Pool{
 	},
 }
 
-func writeEscapedForOutput(w io.Writer, str string, escapeQuotes bool) {
+func (l *logger) writeEscapedForOutput(w io.Writer, str string, escapeQuotes bool) {
 	// kindly borrowed from hclog
 	if !needsEscaping(str) {
+		if !l.noStyles {
+			str = ValueStyle.Render(str)
+		}
 		_, _ = w.Write([]byte(str))
 		return
 	}
@@ -115,7 +118,12 @@ func writeEscapedForOutput(w io.Writer, str string, escapeQuotes bool) {
 		}
 	}
 
-	_, _ = w.Write(bb.Bytes())
+	s := bb.String()
+	if !l.noStyles {
+		s = ValueStyle.Render(s)
+	}
+
+	_, _ = w.Write([]byte(s))
 }
 
 // isNormal indicates if the rune is one allowed to exist as an unquoted
@@ -206,14 +214,6 @@ func (l *logger) textFormatter(keyvals ...interface{}) {
 					key = KeyStyle.Render(key)
 				}
 			}
-			if !strings.Contains(val, "\n") && !raw && needsQuoting(val) {
-				b := &bytes.Buffer{}
-				writeEscapedForOutput(b, val, true)
-				val = b.String()
-			}
-			if !l.noStyles {
-				val = ValueStyle.Render(val)
-			}
 
 			// Values may contain multiple lines, and that format
 			// is preserved, with each line prefixed with a "  | "
@@ -226,7 +226,7 @@ func (l *logger) textFormatter(keyvals ...interface{}) {
 				l.b.WriteString("\n  ")
 				l.b.WriteString(key)
 				l.b.WriteString(sep + "\n")
-				writeIndent(&l.b, val, indentSep, moreKeys)
+				l.writeIndent(&l.b, val, indentSep, moreKeys)
 				// If there are more keyvals, separate them with a space.
 				if moreKeys {
 					l.b.WriteByte(' ')
@@ -236,9 +236,12 @@ func (l *logger) textFormatter(keyvals ...interface{}) {
 				l.b.WriteString(key)
 				l.b.WriteString(sep)
 				l.b.WriteByte('"')
-				l.b.WriteString(val)
+				l.writeEscapedForOutput(&l.b, val, true)
 				l.b.WriteByte('"')
 			} else {
+				if !l.noStyles {
+					val = ValueStyle.Render(val)
+				}
 				l.b.WriteByte(' ')
 				l.b.WriteString(key)
 				l.b.WriteString(sep)

--- a/text.go
+++ b/text.go
@@ -205,6 +205,13 @@ func (l *logger) textFormatter(keyvals ...interface{}) {
 				} else {
 					key = KeyStyle.Render(key)
 				}
+			}
+			if !strings.Contains(val, "\n") && !raw && needsQuoting(val) {
+				b := &bytes.Buffer{}
+				writeEscapedForOutput(b, val, true)
+				val = b.String()
+			}
+			if !l.noStyles {
 				val = ValueStyle.Render(val)
 			}
 
@@ -229,7 +236,7 @@ func (l *logger) textFormatter(keyvals ...interface{}) {
 				l.b.WriteString(key)
 				l.b.WriteString(sep)
 				l.b.WriteByte('"')
-				writeEscapedForOutput(&l.b, val, true)
+				l.b.WriteString(val)
 				l.b.WriteByte('"')
 			} else {
 				l.b.WriteByte(' ')

--- a/text_test.go
+++ b/text_test.go
@@ -250,6 +250,13 @@ func TestTextValueStyles(t *testing.T) {
 			f:        logger.Info,
 		},
 		{
+			name:     "ignored message",
+			expected: "",
+			msg:      "this is a debug message",
+			kvs:      nil,
+			f:        logger.Debug,
+		},
+		{
 			name: "message with keyvals",
 			expected: fmt.Sprintf(
 				"%s info %s%s%s %s%s%s\n",
@@ -259,18 +266,6 @@ func TestTextValueStyles(t *testing.T) {
 			),
 			msg: "info",
 			kvs: []interface{}{"key1", "val1", "key2", "val2"},
-			f:   logger.Info,
-		},
-		{
-			name: "message with keyvals",
-			expected: fmt.Sprintf(
-				"%s info %s%s%s %s%s%s\n",
-				InfoLevelStyle.Render("INFO"),
-				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("true"),
-				KeyStyle.Render("key2"), SeparatorStyle.Render("="), ValueStyle.Render("false"),
-			),
-			msg: "info",
-			kvs: []interface{}{"key1", true, "key2", false},
 			f:   logger.Info,
 		},
 		{
@@ -284,6 +279,42 @@ func TestTextValueStyles(t *testing.T) {
 			),
 			msg: "info",
 			kvs: []interface{}{"key1", "val1\nval2"},
+			f:   logger.Error,
+		},
+		{
+			name: "error message with keyvals",
+			expected: fmt.Sprintf(
+				"%s info %s%s%s %s%s%s\n",
+				ErrorLevelStyle.Render("ERRO"),
+				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("val1"),
+				KeyStyle.Render("key2"), SeparatorStyle.Render("="), ValueStyle.Render("val2"),
+			),
+			msg: "info",
+			kvs: []interface{}{"key1", "val1", "key2", "val2"},
+			f:   logger.Error,
+		},
+		{
+			name: "odd number of keyvals",
+			expected: fmt.Sprintf(
+				"%s info %s%s%s %s%s%s %s%s\"%s\"\n",
+				ErrorLevelStyle.Render("ERRO"),
+				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("val1"),
+				KeyStyle.Render("key2"), SeparatorStyle.Render("="), ValueStyle.Render("val2"),
+				KeyStyle.Render("key3"), SeparatorStyle.Render("="), ValueStyle.Render("missing value"),
+			),
+			msg: "info",
+			kvs: []interface{}{"key1", "val1", "key2", "val2", "key3"},
+			f:   logger.Error,
+		},
+		{
+			name: "error field",
+			expected: fmt.Sprintf(
+				"%s info %s%s\"%s\"\n",
+				ErrorLevelStyle.Render("ERRO"),
+				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("error value"),
+			),
+			msg: "info",
+			kvs: []interface{}{"key1", errors.New("error value")},
 			f:   logger.Error,
 		},
 		{
@@ -307,6 +338,50 @@ func TestTextValueStyles(t *testing.T) {
 			msg: "info",
 			kvs: []interface{}{"key1", struct{ foo string }{foo: "bar baz"}},
 			f:   logger.Info,
+		},
+		{
+			name: "slice of strings",
+			expected: fmt.Sprintf(
+				"%s info %s%s\"%s\"\n",
+				ErrorLevelStyle.Render("ERRO"),
+				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("[foo bar]"),
+			),
+			msg: "info",
+			kvs: []interface{}{"key1", []string{"foo", "bar"}},
+			f:   logger.Error,
+		},
+		{
+			name: "slice of structs",
+			expected: fmt.Sprintf(
+				"%s info %s%s\"%s\"\n",
+				ErrorLevelStyle.Render("ERRO"),
+				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("[{foo:bar} {foo:baz}]"),
+			),
+			msg: "info",
+			kvs: []interface{}{"key1", []struct{ foo string }{{foo: "bar"}, {foo: "baz"}}},
+			f:   logger.Error,
+		},
+		{
+			name: "slice of errors",
+			expected: fmt.Sprintf(
+				"%s info %s%s\"%s\"\n",
+				ErrorLevelStyle.Render("ERRO"),
+				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("[error value1 error value2]"),
+			),
+			msg: "info",
+			kvs: []interface{}{"key1", []error{errors.New("error value1"), errors.New("error value2")}},
+			f:   logger.Error,
+		},
+		{
+			name: "map of strings",
+			expected: fmt.Sprintf(
+				"%s info %s%s\"%s\"\n",
+				ErrorLevelStyle.Render("ERRO"),
+				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("map[baz:qux foo:bar]"),
+			),
+			msg: "info",
+			kvs: []interface{}{"key1", map[string]string{"foo": "bar", "baz": "qux"}},
+			f:   logger.Error,
 		},
 	}
 	for _, c := range cases {

--- a/text_test.go
+++ b/text_test.go
@@ -252,7 +252,7 @@ func TestTextValueStyles(t *testing.T) {
 		{
 			name: "message with keyvals",
 			expected: fmt.Sprintf(
-				"%s info %s%s\"%s\" %s%s\"%s\"\n",
+				"%s info %s%s%s %s%s%s\n",
 				InfoLevelStyle.Render("INFO"),
 				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("val1"),
 				KeyStyle.Render("key2"), SeparatorStyle.Render("="), ValueStyle.Render("val2"),
@@ -264,7 +264,7 @@ func TestTextValueStyles(t *testing.T) {
 		{
 			name: "message with keyvals",
 			expected: fmt.Sprintf(
-				"%s info %s%s\"%s\" %s%s\"%s\"\n",
+				"%s info %s%s%s %s%s%s\n",
 				InfoLevelStyle.Render("INFO"),
 				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("true"),
 				KeyStyle.Render("key2"), SeparatorStyle.Render("="), ValueStyle.Render("false"),
@@ -274,9 +274,22 @@ func TestTextValueStyles(t *testing.T) {
 			f:   logger.Info,
 		},
 		{
+			name: "error message with multiline",
+			expected: fmt.Sprintf(
+				"%s info\n  %s%s\n%s%s\n%s%s\n",
+				ErrorLevelStyle.Render("ERRO"),
+				KeyStyle.Render("key1"), SeparatorStyle.Render("="),
+				SeparatorStyle.Render("  │ "), ValueStyle.Render("val1"),
+				SeparatorStyle.Render("  │ "), ValueStyle.Render("val2"),
+			),
+			msg: "info",
+			kvs: []interface{}{"key1", "val1\nval2"},
+			f:   logger.Error,
+		},
+		{
 			name: "struct field",
 			expected: fmt.Sprintf(
-				"%s info %s%s\"%s\"\n",
+				"%s info %s%s%s\n",
 				InfoLevelStyle.Render("INFO"),
 				KeyStyle.Render("key1"), SeparatorStyle.Render("="), ValueStyle.Render("{foo:bar}"),
 			),


### PR DESCRIPTION
Update to essentially render lipgloss styles for values after escaping and indenting.

- Add `l *looger` receiver to `writeEscapedForOutput` for access to `l.noStyles`
- Add `l *logger` receiver to `writeIdent` to be able to call the updated `writeEscapedForOutput`
- Update `writeEscapedForOutput` to call `ValueStyle.Render` after escaping the values, or if the values don't need need escaping

Fix #19 

