### PR TITLE
feat(log): add format methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ log.Fatal(err) // this calls os.Exit(1)
 log.Print(err) // prints regardless of log level
 ```
 
+Or use the formatter variant:
+
+```go
+format := "%s %d"
+log.Debugf(format, "chocolate", 10)
+log.Warnf(format, "adding more", 5)
+log.Errorf(format, "increasing temp", 420)
+log.Fatalf(format, "too hot!", 500) // this calls os.Exit(1)
+log.Printf(format, "baking cookies") // prints regardless of log level
+
+// Use these in conjunction with `With(...)` to add more context
+log.With("err", err).Errorf("unable to start %s", "oven")
+```
+
 ### Structured
 
 All the functions above take a message and key-value pairs of anything. The

--- a/logger.go
+++ b/logger.go
@@ -296,32 +296,32 @@ func (l *Logger) Print(msg interface{}, keyvals ...interface{}) {
 }
 
 // Debugf prints a debug message with formatting.
-func (l *logger) Debugf(format string, args ...interface{}) {
+func (l *Logger) Debugf(format string, args ...interface{}) {
 	l.log(DebugLevel, fmt.Sprintf(format, args...))
 }
 
 // Infof prints an info message with formatting.
-func (l *logger) Infof(format string, args ...interface{}) {
+func (l *Logger) Infof(format string, args ...interface{}) {
 	l.log(InfoLevel, fmt.Sprintf(format, args...))
 }
 
 // Warnf prints a warning message with formatting.
-func (l *logger) Warnf(format string, args ...interface{}) {
+func (l *Logger) Warnf(format string, args ...interface{}) {
 	l.log(WarnLevel, fmt.Sprintf(format, args...))
 }
 
 // Errorf prints an error message with formatting.
-func (l *logger) Errorf(format string, args ...interface{}) {
+func (l *Logger) Errorf(format string, args ...interface{}) {
 	l.log(ErrorLevel, fmt.Sprintf(format, args...))
 }
 
 // Fatalf prints a fatal message with formatting and exits.
-func (l *logger) Fatalf(format string, args ...interface{}) {
+func (l *Logger) Fatalf(format string, args ...interface{}) {
 	l.log(FatalLevel, fmt.Sprintf(format, args...))
 	os.Exit(1)
 }
 
 // Printf prints a message with no level and formatting.
-func (l *logger) Printf(format string, args ...interface{}) {
+func (l *Logger) Printf(format string, args ...interface{}) {
 	l.log(noLevel, fmt.Sprintf(format, args...))
 }

--- a/logger.go
+++ b/logger.go
@@ -294,3 +294,34 @@ func (l *Logger) Fatal(msg interface{}, keyvals ...interface{}) {
 func (l *Logger) Print(msg interface{}, keyvals ...interface{}) {
 	l.log(noLevel, msg, keyvals...)
 }
+
+// Debugf prints a debug message with formatting.
+func (l *logger) Debugf(format string, args ...interface{}) {
+	l.log(DebugLevel, fmt.Sprintf(format, args...))
+}
+
+// Infof prints an info message with formatting.
+func (l *logger) Infof(format string, args ...interface{}) {
+	l.log(InfoLevel, fmt.Sprintf(format, args...))
+}
+
+// Warnf prints a warning message with formatting.
+func (l *logger) Warnf(format string, args ...interface{}) {
+	l.log(WarnLevel, fmt.Sprintf(format, args...))
+}
+
+// Errorf prints an error message with formatting.
+func (l *logger) Errorf(format string, args ...interface{}) {
+	l.log(ErrorLevel, fmt.Sprintf(format, args...))
+}
+
+// Fatalf prints a fatal message with formatting and exits.
+func (l *logger) Fatalf(format string, args ...interface{}) {
+	l.log(FatalLevel, fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+// Printf prints a message with no level and formatting.
+func (l *logger) Printf(format string, args ...interface{}) {
+	l.log(noLevel, fmt.Sprintf(format, args...))
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -79,7 +79,8 @@ func TestWrongLevel(t *testing.T) {
 
 func TestLogFormatter(t *testing.T) {
 	var buf bytes.Buffer
-	l := New(WithOutput(&buf), WithLevel(DebugLevel))
+	l := New(&buf)
+	l.SetLevel(DebugLevel)
 	cases := []struct {
 		name     string
 		format   string
@@ -99,7 +100,7 @@ func TestLogFormatter(t *testing.T) {
 			format:   "%s %s",
 			args:     []interface{}{"foo", "bar"},
 			fun:      l.Debugf,
-			expected: "DEBUG foo bar\n",
+			expected: "DEBU foo bar\n",
 		},
 		{
 			name:     "warn format",
@@ -113,7 +114,7 @@ func TestLogFormatter(t *testing.T) {
 			format:   "%s %s",
 			args:     []interface{}{"foo", "bar"},
 			fun:      l.Errorf,
-			expected: "ERROR foo bar\n",
+			expected: "ERRO foo bar\n",
 		},
 	}
 	for _, c := range cases {

--- a/logger_test.go
+++ b/logger_test.go
@@ -76,3 +76,51 @@ func TestWrongLevel(t *testing.T) {
 		})
 	}
 }
+
+func TestLogFormatter(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(WithOutput(&buf), WithLevel(DebugLevel))
+	cases := []struct {
+		name     string
+		format   string
+		args     []interface{}
+		fun      func(string, ...interface{})
+		expected string
+	}{
+		{
+			name:     "info format",
+			format:   "%s %s",
+			args:     []interface{}{"foo", "bar"},
+			fun:      l.Infof,
+			expected: "INFO foo bar\n",
+		},
+		{
+			name:     "debug format",
+			format:   "%s %s",
+			args:     []interface{}{"foo", "bar"},
+			fun:      l.Debugf,
+			expected: "DEBUG foo bar\n",
+		},
+		{
+			name:     "warn format",
+			format:   "%s %s",
+			args:     []interface{}{"foo", "bar"},
+			fun:      l.Warnf,
+			expected: "WARN foo bar\n",
+		},
+		{
+			name:     "error format",
+			format:   "%s %s",
+			args:     []interface{}{"foo", "bar"},
+			fun:      l.Errorf,
+			expected: "ERROR foo bar\n",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buf.Reset()
+			c.fun(c.format, "foo", "bar")
+			assert.Equal(t, c.expected, buf.String())
+		})
+	}
+}

--- a/pkg.go
+++ b/pkg.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -148,6 +149,37 @@ func Fatal(msg interface{}, keyvals ...interface{}) {
 // Print logs a message with no level.
 func Print(msg interface{}, keyvals ...interface{}) {
 	defaultLogger.log(noLevel, msg, keyvals...)
+}
+
+// Debugf logs a debug message with formatting.
+func Debugf(format string, args ...interface{}) {
+	defaultLogger.log(DebugLevel, fmt.Sprintf(format, args...))
+}
+
+// Infof logs an info message with formatting.
+func Infof(format string, args ...interface{}) {
+	defaultLogger.log(InfoLevel, fmt.Sprintf(format, args...))
+}
+
+// Warnf logs a warning message with formatting.
+func Warnf(format string, args ...interface{}) {
+	defaultLogger.log(WarnLevel, fmt.Sprintf(format, args...))
+}
+
+// Errorf logs an error message with formatting.
+func Errorf(format string, args ...interface{}) {
+	defaultLogger.log(ErrorLevel, fmt.Sprintf(format, args...))
+}
+
+// Fatalf logs a fatal message with formatting and exit.
+func Fatalf(format string, args ...interface{}) {
+	defaultLogger.log(FatalLevel, fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+// Printf logs a message with formatting and no level.
+func Printf(format string, args ...interface{}) {
+	defaultLogger.log(noLevel, fmt.Sprintf(format, args...))
 }
 
 // StandardLog returns a standard logger from the default logger.

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -2,9 +2,13 @@ package log
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -56,12 +60,31 @@ func TestPrint(t *testing.T) {
 	SetOutput(&buf)
 	SetLevel(FatalLevel)
 	SetTimeFunction(_zeroTime)
+	SetReportTimestamp(true)
+	SetReportCaller(false)
+	SetTimeFormat(DefaultTimeFormat)
 	Error("error")
 	Print("print")
 	assert.Equal(t, "0001/01/01 00:00:00 print\n", buf.String())
 }
 
+func TestPrintf(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(FatalLevel)
+	SetTimeFunction(_zeroTime)
+	SetReportTimestamp(true)
+	SetReportCaller(false)
+	SetTimeFormat(DefaultTimeFormat)
+	Errorf("error")
+	Printf("print")
+	assert.Equal(t, "0001/01/01 00:00:00 print\n", buf.String())
+}
+
 func TestFatal(t *testing.T) {
+	SetReportTimestamp(true)
+	SetReportCaller(false)
+	SetTimeFormat(DefaultTimeFormat)
 	if os.Getenv("FATAL") == "1" {
 		Fatal("i'm dead")
 		return
@@ -73,4 +96,110 @@ func TestFatal(t *testing.T) {
 		return
 	}
 	t.Fatalf("process ran with err %v, want exit status 1", err)
+}
+
+func TestFatalf(t *testing.T) {
+	SetReportTimestamp(true)
+	SetReportCaller(false)
+	SetTimeFormat(DefaultTimeFormat)
+	if os.Getenv("FATAL") == "1" {
+		Fatalf("i'm %s", "dead")
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestFatalf")
+	cmd.Env = append(os.Environ(), "FATAL=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 1", err)
+}
+
+func TestDebugf(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(DebugLevel)
+	SetTimeFunction(_zeroTime)
+	SetReportTimestamp(true)
+	SetReportCaller(true)
+	SetTimeFormat(DefaultTimeFormat)
+	_, file, line, _ := runtime.Caller(0)
+	Debugf("debug %s", "foo")
+	assert.Equal(t, fmt.Sprintf("0001/01/01 00:00:00 DEBU <log/%s:%d> debug foo\n", filepath.Base(file), line+1), buf.String())
+}
+
+func TestInfof(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(InfoLevel)
+	SetReportTimestamp(false)
+	SetReportCaller(false)
+	SetTimeFormat(DefaultTimeFormat)
+	Infof("info %s", "foo")
+	assert.Equal(t, "INFO info foo\n", buf.String())
+}
+
+func TestWarnf(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(WarnLevel)
+	SetReportCaller(false)
+	SetReportTimestamp(true)
+	SetTimeFunction(_zeroTime)
+	SetTimeFormat(DefaultTimeFormat)
+	Warnf("warn %s", "foo")
+	assert.Equal(t, "0001/01/01 00:00:00 WARN warn foo\n", buf.String())
+}
+
+func TestErrorf(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(ErrorLevel)
+	SetReportCaller(false)
+	SetReportTimestamp(true)
+	SetTimeFunction(_zeroTime)
+	SetTimeFormat(time.Kitchen)
+	Errorf("error %s", "foo")
+	assert.Equal(t, "12:00AM ERRO error foo\n", buf.String())
+}
+
+func TestWith(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(InfoLevel)
+	SetReportCaller(false)
+	SetReportTimestamp(true)
+	SetTimeFunction(_zeroTime)
+	SetTimeFormat(DefaultTimeFormat)
+	With("foo", "bar").Info("info")
+	assert.Equal(t, "0001/01/01 00:00:00 INFO info foo=bar\n", buf.String())
+}
+
+func TestGetLevel(t *testing.T) {
+	SetLevel(InfoLevel)
+	assert.Equal(t, InfoLevel, GetLevel())
+}
+
+func TestPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(InfoLevel)
+	SetReportCaller(false)
+	SetReportTimestamp(false)
+	SetPrefix("prefix")
+	Info("info")
+	assert.Equal(t, "INFO prefix: info\n", buf.String())
+	assert.Equal(t, "prefix", GetPrefix())
+	SetPrefix("")
+}
+
+func TestFormatter(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	SetLevel(InfoLevel)
+	SetReportCaller(false)
+	SetReportTimestamp(false)
+	SetFormatter(JSONFormatter)
+	Info("info")
+	assert.Equal(t, "{\"lvl\":\"info\",\"msg\":\"info\"}\n", buf.String())
 }


### PR DESCRIPTION
Adds `Debugf`, `Infof`,  `Warnf`, `Errorf`, `Fatalf`, and `Printf`. Use these in conjunction with `With(...)` to add more context to the log. `log.With("err", err).Errorf("user %s", user)`

Fixes: https://github.com/charmbracelet/log/issues/32