### PR TITLE
Allow updating of the logger in context

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,17 +7,35 @@ func WithContext(ctx context.Context, logger Logger, keyvals ...interface{}) con
 	if len(keyvals) > 0 {
 		logger = logger.With(keyvals...)
 	}
-	return context.WithValue(ctx, loggerContextKey, logger)
+	return context.WithValue(ctx, loggerContextKey, &logger)
 }
 
 // FromContext returns the logger from the given context.
 // This will return the default package logger if no logger
 // found in context.
 func FromContext(ctx context.Context) Logger {
-	if logger, ok := ctx.Value(loggerContextKey).(Logger); ok {
-		return logger
+	if logger, ok := ctx.Value(loggerContextKey).(*Logger); ok {
+		return *logger
 	}
 	return defaultLogger
+}
+
+// UpdateContext updates the logger in the given context. Returns a boolean if the logger was
+// successfully updated. If there's no logger in the context, this will return false.
+func UpdateContext(ctx context.Context, fn func(Logger) Logger) bool {
+	loggerPtr := ctx.Value(loggerContextKey)
+	if loggerPtr == nil {
+		return false
+	}
+
+	logger, ok := loggerPtr.(*Logger)
+	if !ok {
+		return false
+	}
+
+	*logger = fn(*logger)
+
+	return true
 }
 
 type contextKey struct{}

--- a/context_test.go
+++ b/context_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,4 +27,64 @@ func TestLogContext_fields(t *testing.T) {
 	require.NotNil(t, l)
 	l.Debug("test")
 	require.Equal(t, "DEBUG test foo=bar\n", buf.String())
+}
+
+func TestLogUpdateContext(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(WithOutput(&buf))
+	logger.SetLevel(DebugLevel)
+	t.Run("with extra parameters", func(t *testing.T) {
+		ctx := WithContext(context.Background(), logger, "key", "value")
+
+		assert.True(t, UpdateContext(ctx, func(logger Logger) Logger {
+			return logger.With("key2", "value2")
+		}))
+
+		buf.Reset()
+		FromContext(ctx).Info("test")
+		assert.Equal(t, "INFO test key=value key2=value2\n", buf.String())
+
+		// original logger should not be changed
+		buf.Reset()
+		logger.Debug("test2")
+		assert.Equal(t, "DEBUG test2\n", buf.String())
+	})
+
+	t.Run("without extra parameters", func(t *testing.T) {
+		ctx := WithContext(context.Background(), logger)
+
+		assert.True(t, UpdateContext(ctx, func(logger Logger) Logger {
+			return logger.With("key3", "value3")
+		}))
+
+		buf.Reset()
+		FromContext(ctx).Info("test3")
+		assert.Equal(t, "INFO test3 key3=value3\n", buf.String())
+
+		// original logger should not be changed
+		buf.Reset()
+		logger.Debug("test4")
+		assert.Equal(t, "DEBUG test4\n", buf.String())
+	})
+
+	t.Run("with consecutive calls", func(t *testing.T) {
+		ctx := WithContext(context.Background(), logger)
+
+		assert.True(t, UpdateContext(ctx, func(logger Logger) Logger {
+			return logger.With("key4", "value4")
+		}))
+		assert.True(t, UpdateContext(ctx, func(logger Logger) Logger {
+			return logger.With("key5", "value5")
+		}))
+
+		buf.Reset()
+		FromContext(ctx).Info("test5")
+		assert.Equal(t, "INFO test5 key4=value4 key5=value5\n", buf.String())
+	})
+
+	t.Run("without log in context", func(t *testing.T) {
+		assert.False(t, UpdateContext(context.Background(), func(logger Logger) Logger {
+			return logger
+		}))
+	})
 }


### PR DESCRIPTION
Sometimes we need to update the logger that is in the context to add fields. An example use-case is a logger middleware that injects the logger to a context, and the next middleware detects that a user is logged in and we want to log the userID when the logger middleware outputs the message, after the message is processed.

These changes do not compromise any other usages. Everything else behaves the same.

The following overly simplified code can illustrate the usage proposed on this PR:

```go

func LoggerMiddleware(next http.Handler) http.Handler {
	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
		start := time.Now()

		correlationID := xid.New().String()
		ctx := log.WithContext(r.Context(), log.Ctx(r.Context()), "correlation_id", correlationID)

		defer func() {
			logger := log.FromContext(ctx)
			logger.Info("request", "path", r.URL.Path, "method", r.Method, "duration", time.Since(start))
		}()

		next.ServeHTTP(rw, r.WithContext(ctx))
	})
}

func UserDetectorMiddleware(next http.Handler) http.Handler {
	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
		user := db.FindUser(r)
		ctx := r.Context()
		if user != nil {
			updateResp := log.UpdateContext(ctx, func(logger log.Logger) log.Logger {
				return logger.With("user_id", user.ID)
			})


			if !updateResp {
				log.Warn("cannot update context")
			}

			ctx = updateContextWithUser(ctx, user)
		}

		next.ServeHTTP(rw, r.WithContext(ctx))
	})
}
```