### PR TITLE
Allow the user to force color output on non-tty devices

### DIFF
--- a/options.go
+++ b/options.go
@@ -58,5 +58,6 @@ type Options struct {
 	Fields []interface{}
 	// Formatter is the formatter for the logger. The default is TextFormatter.
 	Formatter Formatter
-	
+	// ForceColors is whether the logger should force colors. The default is false.
+	ForceColors bool
 }

--- a/pkg.go
+++ b/pkg.go
@@ -49,6 +49,7 @@ func NewWithOptions(w io.Writer, o Options) *Logger {
 		fields:          o.Fields,
 		callerFormatter: o.CallerFormatter,
 		callerOffset:    o.CallerOffset,
+		forceColors:     o.ForceColors,
 	}
 
 	l.SetOutput(w)
@@ -127,6 +128,10 @@ func SetPrefix(prefix string) {
 // GetPrefix returns the prefix for the default logger.
 func GetPrefix() string {
 	return defaultLogger.GetPrefix()
+}
+
+func SetForceColors(force bool) {
+	defaultLogger.SetForceColors(force)
 }
 
 // With returns a new logger with the given keyvals.


### PR DESCRIPTION
I used this workflow when using io.Pipe, allowing me to redirect the logging output to a viewport.