### PR TITLE
fix log.With() race condition

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -285,9 +285,7 @@ func (l *Logger) SetCallerOffset(offset int) {
 
 // With returns a new logger with the given keyvals added.
 func (l *Logger) With(keyvals ...interface{}) *Logger {
-	l.mu.Lock()
 	sl := *l
-	l.mu.Unlock()
 	sl.b = bytes.Buffer{}
 	sl.mu = &sync.RWMutex{}
 	sl.helpers = &sync.Map{}

--- a/logger.go
+++ b/logger.go
@@ -285,7 +285,9 @@ func (l *Logger) SetCallerOffset(offset int) {
 
 // With returns a new logger with the given keyvals added.
 func (l *Logger) With(keyvals ...interface{}) *Logger {
+	l.mu.Lock()
 	sl := *l
+	l.mu.Unlock()
 	sl.b = bytes.Buffer{}
 	sl.mu = &sync.RWMutex{}
 	sl.helpers = &sync.Map{}


### PR DESCRIPTION
- added small unittest to highlight the problem
- problem only visible when running with `-race` option