### PR TITLE
feat: set lipgloss renderer color profile

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -282,6 +282,12 @@ func (l *Logger) SetCallerOffset(offset int) {
 	l.callerOffset = offset
 }
 
+// SetColorProfile force sets the underlying Lip Gloss renderer color profile
+// for the TextFormatter.
+func (l *Logger) SetColorProfile(profile termenv.Profile) {
+	l.re.SetColorProfile(profile)
+}
+
 // With returns a new logger with the given keyvals added.
 func (l *Logger) With(keyvals ...interface{}) *Logger {
 	l.mu.Lock()

--- a/pkg.go
+++ b/pkg.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/muesli/termenv"
 )
 
 var (
@@ -122,6 +124,12 @@ func SetCallerOffset(offset int) {
 // SetPrefix sets the prefix for the default logger.
 func SetPrefix(prefix string) {
 	defaultLogger.SetPrefix(prefix)
+}
+
+// SetColorProfile force sets the underlying Lip Gloss renderer color profile
+// for the TextFormatter.
+func SetColorProfile(profile termenv.Profile) {
+	defaultLogger.SetColorProfile(profile)
 }
 
 // GetPrefix returns the prefix for the default logger.

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,6 +64,7 @@ func TestPrint(t *testing.T) {
 	SetReportTimestamp(true)
 	SetReportCaller(false)
 	SetTimeFormat(DefaultTimeFormat)
+	SetColorProfile(termenv.ANSI)
 	Error("error")
 	Print("print")
 	assert.Equal(t, "0001/01/01 00:00:00 print\n", buf.String())

--- a/text_test.go
+++ b/text_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -394,5 +396,19 @@ func TestTextValueStyles(t *testing.T) {
 			c.f(c.msg, c.kvs...)
 			assert.Equal(t, c.expected, buf.String())
 		})
+	}
+}
+
+func TestColorProfile(t *testing.T) {
+	cases := []termenv.Profile{
+		termenv.Ascii,
+		termenv.ANSI,
+		termenv.ANSI256,
+		termenv.TrueColor,
+	}
+	l := New(io.Discard)
+	for _, p := range cases {
+		l.SetColorProfile(p)
+		assert.Equal(t, p, l.re.ColorProfile())
 	}
 }


### PR DESCRIPTION
Add `SetColorProfile` to force change the Lip Gloss renderer color profile.

Needs: https://github.com/charmbracelet/lipgloss/pull/212
Fixes: https://github.com/charmbracelet/log/pull/63