### PR TITLE
fix(ci): fail ci on lint issues; enable nolintlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: golangci-lint command line arguments.
-          args: --issues-exit-code=0
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          only-new-issues: true
+          args: --issues-exit-code=1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - gosec
     - ifshort
     - misspell
+    - nolintlint
     - prealloc
     - revive
     - rowserrcheck

--- a/logger.go
+++ b/logger.go
@@ -106,7 +106,7 @@ func (l *Logger) log(level Level, msg interface{}, keyvals ...interface{}) {
 	}
 
 	// WriteTo will reset the buffer
-	l.b.WriteTo(l.w) // nolint: errcheck
+	l.b.WriteTo(l.w) //nolint: errcheck
 }
 
 // Helper marks the calling function as a helper

--- a/options.go
+++ b/options.go
@@ -27,12 +27,12 @@ type CallerFormatter func(string, int, string) string
 
 // ShortCallerFormatter is a caller formatter that returns the last 2 levels of the path
 // and line number.
-func ShortCallerFormatter(file string, line int, funcName string) string {
+func ShortCallerFormatter(file string, line int, _ string) string {
 	return fmt.Sprintf("%s:%d", trimCallerPath(file, 2), line)
 }
 
 // LongCallerFormatter is a caller formatter that returns the full path and line number.
-func LongCallerFormatter(file string, line int, funcName string) string {
+func LongCallerFormatter(file string, line int, _ string) string {
 	return fmt.Sprintf("%s:%d", file, line)
 }
 
@@ -58,5 +58,4 @@ type Options struct {
 	Fields []interface{}
 	// Formatter is the formatter for the logger. The default is TextFormatter.
 	Formatter Formatter
-	
 }


### PR DESCRIPTION
This PR:
- modifies `.github/workflows/lint.yml` to fail CI on lint failures;
- enables `nolintlint` linter;
- fix all lint issues.