### PR TITLE
docs: direct users to library API

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
 For those of you who are new to Go, check out
-[pkg.go.dev](https://https://pkg.go.dev/github.com/charmbracelet/bubbletea) to
+[pkg.go.dev](https://https://pkg.go.dev/github.com/charmbracelet/log) to
 view our library's API. From there, you can search the repo for more detailed
 usage examples for whichever functions match your use case.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,6 @@
+# Examples
+
+For those of you who are new to Go, check out
+[pkg.go.dev](https://https://pkg.go.dev/github.com/charmbracelet/bubbletea) to
+view our library's API. From there, you can search the repo for more detailed
+usage examples for whichever functions match your use case.


### PR DESCRIPTION
In an attempt to improve our documentation while keeping the cost of maintenance as low as possible, I think it would be valuable to direct users on how to use the examples provided. A lot of people who are new to Go aren't aware that they can see the godoc of our packages online. 

Lmk your thoughts, I *think* this disclosure makes it easier for users to learn to find what they're looking for.
