### PR TITLE
Return Error from ParseLevel

### DIFF
--- a/level.go
+++ b/level.go
@@ -59,6 +59,6 @@ func ParseLevel(level string) (Level, error) {
 	case FatalLevel.String():
 		return FatalLevel, nil
 	default:
-		return 0, fmt.Errorf("%w: %q", ErrInvalidLevel, level)
+		return InfoLevel, fmt.Errorf("%w: %q", ErrInvalidLevel, level)
 	}
 }

--- a/level.go
+++ b/level.go
@@ -41,10 +41,8 @@ func (l Level) String() string {
 	}
 }
 
-func parseLevelError(level string) error {
-	return fmt.Errorf("invalid level %s", strings.ToLower(level))
-}
-
+// ErrInvalidLevel is an error returned when parsing an invalid level string.
+var ErrInvalidLevel = errors.New("invalid level")
 // ParseLevel converts level in string to Level type. Default level is InfoLevel.
 func ParseLevel(level string) (Level, error) {
 	switch strings.ToLower(level) {
@@ -59,6 +57,6 @@ func ParseLevel(level string) (Level, error) {
 	case FatalLevel.String():
 		return FatalLevel, nil
 	default:
-		return InfoLevel, parseLevelError(level)
+		return InfoLevel, fmt.Errorf("%w: %q", ErrInvalidLevel, level)
 	}
 }

--- a/level.go
+++ b/level.go
@@ -59,6 +59,6 @@ func ParseLevel(level string) (Level, error) {
 	case FatalLevel.String():
 		return FatalLevel, nil
 	default:
-		return InfoLevel, fmt.Errorf("%w: %q", ErrInvalidLevel, level)
+		return defaultLogger.GetLevel(), fmt.Errorf("%w: %q", ErrInvalidLevel, level)
 	}
 }

--- a/level.go
+++ b/level.go
@@ -59,6 +59,6 @@ func ParseLevel(level string) (Level, error) {
 	case FatalLevel.String():
 		return FatalLevel, nil
 	default:
-		return InfoLevel, fmt.Errorf("%w: %q", ErrInvalidLevel, level)
+		return 0, fmt.Errorf("%w: %q", ErrInvalidLevel, level)
 	}
 }

--- a/level.go
+++ b/level.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -43,6 +44,7 @@ func (l Level) String() string {
 
 // ErrInvalidLevel is an error returned when parsing an invalid level string.
 var ErrInvalidLevel = errors.New("invalid level")
+
 // ParseLevel converts level in string to Level type. Default level is InfoLevel.
 func ParseLevel(level string) (Level, error) {
 	switch strings.ToLower(level) {

--- a/level.go
+++ b/level.go
@@ -1,6 +1,9 @@
 package log
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // Level is a logging level.
 type Level int32
@@ -38,20 +41,24 @@ func (l Level) String() string {
 	}
 }
 
+func parseLevelError(level string) error {
+	return fmt.Errorf("invalid level %s", strings.ToLower(level))
+}
+
 // ParseLevel converts level in string to Level type. Default level is InfoLevel.
-func ParseLevel(level string) Level {
+func ParseLevel(level string) (Level, error) {
 	switch strings.ToLower(level) {
 	case DebugLevel.String():
-		return DebugLevel
+		return DebugLevel, nil
 	case InfoLevel.String():
-		return InfoLevel
+		return InfoLevel, nil
 	case WarnLevel.String():
-		return WarnLevel
+		return WarnLevel, nil
 	case ErrorLevel.String():
-		return ErrorLevel
+		return ErrorLevel, nil
 	case FatalLevel.String():
-		return FatalLevel
+		return FatalLevel, nil
 	default:
-		return InfoLevel
+		return InfoLevel, parseLevelError(level)
 	}
 }

--- a/level.go
+++ b/level.go
@@ -59,6 +59,6 @@ func ParseLevel(level string) (Level, error) {
 	case FatalLevel.String():
 		return FatalLevel, nil
 	default:
-		return defaultLogger.GetLevel(), fmt.Errorf("%w: %q", ErrInvalidLevel, level)
+		return 0, fmt.Errorf("%w: %q", ErrInvalidLevel, level)
 	}
 }

--- a/level_test.go
+++ b/level_test.go
@@ -14,59 +14,59 @@ func TestDefaultLevel(t *testing.T) {
 
 func TestParseLevel(t *testing.T) {
 	testCases := []struct {
-		name   string
-		input  string
-		result Level
-		error  error
+		name     string
+		input    string
+		expected Level
+		error    error
 	}{
 		{
-			name:   "Parse debug",
-			input:  "debug",
-			result: DebugLevel,
-			error:  nil,
+			name:     "Parse debug",
+			input:    "debug",
+			expected: DebugLevel,
+			error:    nil,
 		},
 		{
-			name:   "Parse info",
-			input:  "Info",
-			result: InfoLevel,
-			error:  nil,
+			name:     "Parse info",
+			input:    "Info",
+			expected: InfoLevel,
+			error:    nil,
 		},
 		{
-			name:   "Parse warn",
-			input:  "WARN",
-			result: WarnLevel,
-			error:  nil,
+			name:     "Parse warn",
+			input:    "WARN",
+			expected: WarnLevel,
+			error:    nil,
 		},
 		{
-			name:   "Parse error",
-			input:  "error",
-			result: ErrorLevel,
-			error:  nil,
+			name:     "Parse error",
+			input:    "error",
+			expected: ErrorLevel,
+			error:    nil,
 		},
 		{
-			name:   "Parse fatal",
-			input:  "FATAL",
-			result: FatalLevel,
-			error:  nil,
+			name:     "Parse fatal",
+			input:    "FATAL",
+			expected: FatalLevel,
+			error:    nil,
 		},
 		{
-			name:   "Default",
-			input:  "",
-			result: InfoLevel,
-			error:  fmt.Errorf("%w: %q", ErrInvalidLevel, ""),
+			name:     "Default",
+			input:    "",
+			expected: InfoLevel,
+			error:    fmt.Errorf("%w: %q", ErrInvalidLevel, ""),
 		},
 		{
-			name:   "Wrong level, set INFO",
-			input:  "WRONG_LEVEL",
-			result: InfoLevel,
-			error:  fmt.Errorf("%w: %q", ErrInvalidLevel, "WRONG_LEVEL"),
+			name:     "Wrong level, set INFO",
+			input:    "WRONG_LEVEL",
+			expected: InfoLevel,
+			error:    fmt.Errorf("%w: %q", ErrInvalidLevel, "WRONG_LEVEL"),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			lvl, err := ParseLevel(tc.input)
-			assert.Equal(t, tc.result, lvl)
+			assert.Equal(t, tc.expected, lvl)
 			assert.Equal(t, tc.error, err)
 		})
 	}

--- a/level_test.go
+++ b/level_test.go
@@ -10,52 +10,59 @@ func TestDefaultLevel(t *testing.T) {
 	var level Level
 	assert.Equal(t, InfoLevel, level)
 }
+
+type parseLevelResult struct {
+	level Level
+	err   error
+}
+
 func TestParseLevel(t *testing.T) {
 	testCases := []struct {
-		name     string
-		level    string
-		expLevel Level
+		name   string
+		input  string
+		result parseLevelResult
 	}{
 		{
-			name:     "Parse debug",
-			level:    "debug",
-			expLevel: DebugLevel,
+			name:   "Parse debug",
+			input:  "debug",
+			result: parseLevelResult{DebugLevel, nil},
 		},
 		{
-			name:     "Parse info",
-			level:    "Info",
-			expLevel: InfoLevel,
+			name:   "Parse info",
+			input:  "Info",
+			result: parseLevelResult{InfoLevel, nil},
 		},
 		{
-			name:     "Parse warn",
-			level:    "WARN",
-			expLevel: WarnLevel,
+			name:   "Parse warn",
+			input:  "WARN",
+			result: parseLevelResult{WarnLevel, nil},
 		},
 		{
-			name:     "Parse error",
-			level:    "error",
-			expLevel: ErrorLevel,
+			name:   "Parse error",
+			input:  "error",
+			result: parseLevelResult{ErrorLevel, nil},
 		},
 		{
-			name:     "Parse fatal",
-			level:    "FATAL",
-			expLevel: FatalLevel,
+			name:   "Parse fatal",
+			input:  "FATAL",
+			result: parseLevelResult{FatalLevel, nil},
 		},
 		{
-			name:     "Default",
-			level:    "",
-			expLevel: InfoLevel,
+			name:   "Default",
+			input:  "",
+			result: parseLevelResult{InfoLevel, parseLevelError("")},
 		},
 		{
-			name:     "Wrong level, set INFO",
-			level:    "WRONG_LEVEL",
-			expLevel: InfoLevel,
+			name:   "Wrong level, set INFO",
+			input:  "WRONG_LEVEL",
+			result: parseLevelResult{InfoLevel, parseLevelError("WRONG_LEVEL")},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expLevel, ParseLevel(tc.level))
+			lvl, err := ParseLevel(tc.input)
+			assert.Equal(t, tc.result, parseLevelResult{lvl, err})
 		})
 	}
 }

--- a/level_test.go
+++ b/level_test.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -54,13 +53,13 @@ func TestParseLevel(t *testing.T) {
 			name:   "Default",
 			input:  "",
 			result: InfoLevel,
-			error:  fmt.Errorf("%w: %q", errors.New("invalid level"), ""),
+			error:  fmt.Errorf("%w: %q", ErrInvalidLevel, ""),
 		},
 		{
 			name:   "Wrong level, set INFO",
 			input:  "WRONG_LEVEL",
 			result: InfoLevel,
-			error:  fmt.Errorf("%w: %q", errors.New("invalid level"), "WRONG_LEVEL"),
+			error:  fmt.Errorf("%w: %q", ErrInvalidLevel, "WRONG_LEVEL"),
 		},
 	}
 

--- a/level_test.go
+++ b/level_test.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,49 +18,57 @@ func TestParseLevel(t *testing.T) {
 		name   string
 		input  string
 		result Level
-		error error
+		error  error
 	}{
 		{
 			name:   "Parse debug",
 			input:  "debug",
-			result: parseLevelResult{DebugLevel, nil},
+			result: DebugLevel,
+			error:  nil,
 		},
 		{
 			name:   "Parse info",
 			input:  "Info",
-			result: parseLevelResult{InfoLevel, nil},
+			result: InfoLevel,
+			error:  nil,
 		},
 		{
 			name:   "Parse warn",
 			input:  "WARN",
-			result: parseLevelResult{WarnLevel, nil},
+			result: WarnLevel,
+			error:  nil,
 		},
 		{
 			name:   "Parse error",
 			input:  "error",
-			result: parseLevelResult{ErrorLevel, nil},
+			result: ErrorLevel,
+			error:  nil,
 		},
 		{
 			name:   "Parse fatal",
 			input:  "FATAL",
-			result: parseLevelResult{FatalLevel, nil},
+			result: FatalLevel,
+			error:  nil,
 		},
 		{
 			name:   "Default",
 			input:  "",
-			result: parseLevelResult{InfoLevel, parseLevelError("")},
+			result: InfoLevel,
+			error:  fmt.Errorf("%w: %q", errors.New("invalid level"), ""),
 		},
 		{
 			name:   "Wrong level, set INFO",
 			input:  "WRONG_LEVEL",
-			result: parseLevelResult{InfoLevel, parseLevelError("WRONG_LEVEL")},
+			result: InfoLevel,
+			error:  fmt.Errorf("%w: %q", errors.New("invalid level"), "WRONG_LEVEL"),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			lvl, err := ParseLevel(tc.input)
-			assert.Equal(t, tc.result, parseLevelResult{lvl, err})
+			assert.Equal(t, tc.result, lvl)
+			assert.Equal(t, tc.error, err)
 		})
 	}
 }

--- a/level_test.go
+++ b/level_test.go
@@ -11,16 +11,12 @@ func TestDefaultLevel(t *testing.T) {
 	assert.Equal(t, InfoLevel, level)
 }
 
-type parseLevelResult struct {
-	level Level
-	err   error
-}
-
 func TestParseLevel(t *testing.T) {
 	testCases := []struct {
 		name   string
 		input  string
-		result parseLevelResult
+		result Level
+		error error
 	}{
 		{
 			name:   "Parse debug",


### PR DESCRIPTION
resolves #79 

this adds an error result to the parse level function.

this change changes the return signature for ParseLevel!

users of ParseLevel will need to handle the error or choose to disregard it.

people will see the 'multiple values in a single context' error like below
```
log on  strict-parse-level [!?] via 🐹 v1.21.3 
  ❯ go test 
# github.com/charmbracelet/log [github.com/charmbracelet/log.test]
.\level_test.go:58:33: multiple-value ParseLevel(tc.level) (value of type (Level, error)) in single-value context
FAIL    github.com/charmbracelet/log [build failed]
```