### PR TITLE
fix: use const colors to skip reading querying for the terminal bg color

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -54,42 +54,27 @@ func DefaultStyles() *Styles {
 				SetString(strings.ToUpper(DebugLevel.String())).
 				Bold(true).
 				MaxWidth(4).
-				Foreground(lipgloss.AdaptiveColor{
-					Light: "63",
-					Dark:  "63",
-				}),
+				Foreground(lipgloss.Color("63")),
 			InfoLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(InfoLevel.String())).
 				Bold(true).
 				MaxWidth(4).
-				Foreground(lipgloss.AdaptiveColor{
-					Light: "39",
-					Dark:  "86",
-				}),
+				Foreground(lipgloss.Color("86")),
 			WarnLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(WarnLevel.String())).
 				Bold(true).
 				MaxWidth(4).
-				Foreground(lipgloss.AdaptiveColor{
-					Light: "208",
-					Dark:  "192",
-				}),
+				Foreground(lipgloss.Color("192")),
 			ErrorLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(ErrorLevel.String())).
 				Bold(true).
 				MaxWidth(4).
-				Foreground(lipgloss.AdaptiveColor{
-					Light: "203",
-					Dark:  "204",
-				}),
+				Foreground(lipgloss.Color("204")),
 			FatalLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(FatalLevel.String())).
 				Bold(true).
 				MaxWidth(4).
-				Foreground(lipgloss.AdaptiveColor{
-					Light: "133",
-					Dark:  "134",
-				}),
+				Foreground(lipgloss.Color("134")),
 		},
 		Keys:   map[string]lipgloss.Style{},
 		Values: map[string]lipgloss.Style{},


### PR DESCRIPTION
Don't use AdaptiveColors and use regular colors instead. This makes the default styles _not_ use HasDarkBackground to determine the terminal background color. HasDarkBackground will query the terminal for the background color using `OSC 11` to determine which color to use in AdaptiveColor.

For users who still want to use AdaptiveColors, they can supply their own custom styles.

Fixes: https://github.com/charmbracelet/log/issues/90