### PR TITLE
slog: Don't log if not enabled at level

### DIFF
--- a/logger_121.go
+++ b/logger_121.go
@@ -22,6 +22,10 @@ func (l *Logger) Enabled(_ context.Context, level slog.Level) bool {
 //
 // Implements slog.Handler.
 func (l *Logger) Handle(_ context.Context, record slog.Record) error {
+	if !l.Enabled(ctx, record.Level) {
+		return nil
+	}
+	
 	fields := make([]interface{}, 0, record.NumAttrs()*2)
 	record.Attrs(func(a slog.Attr) bool {
 		fields = append(fields, a.Key, a.Value.String())


### PR DESCRIPTION
This is a _very naive first attempt_ to fix a potential bug I noticed in this package's integration with slog.

When I used 

```go
slog.SetDefault(slog.New(log.NewWithOptions(out, log.Options{Level: WarnLevel})))
```

I was still seeing `INFO` and `DEBU` logs, and I couldn't figure out why. I think this is the cause -- the slog `Handle` method isn't consulting `Enabled` before handling. slog's builtin Text and JSON handlers consult the enabled level before logging.

Patching this locally fixed the issue for me, so I thought I'd contribute it. Please let me know if this is on the wrong track.