### PR TITLE
docs: Replace `function` with `func` in README sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Skip caller frames in helper functions. Similar to what you can do with
 `testing.TB().Helper()`.
 
 ```go
-function startOven(degree int) {
+func startOven(degree int) {
     log.Helper()
     log.Info("Starting oven", "degree", degree)
 }


### PR DESCRIPTION
Replaced `function` with `func` in the sample code snippet within the README.

I made this change because I thought it was a typo, since `function` is not recognized by Go. However, if you have a particular reason for using `function` in this context, you may ignore this PR.