### PR TITLE
fix: data race in Default and SetDefault

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/muesli/termenv"
@@ -17,25 +18,27 @@ var (
 	registry = sync.Map{}
 
 	// defaultLogger is the default global logger instance.
+	defaultLogger     atomic.Pointer[Logger]
 	defaultLoggerOnce sync.Once
-	defaultLogger     *Logger
 )
 
 // Default returns the default logger. The default logger comes with timestamp enabled.
 func Default() *Logger {
-	defaultLoggerOnce.Do(func() {
-		if defaultLogger != nil {
-			// already set via SetDefault.
-			return
-		}
-		defaultLogger = NewWithOptions(os.Stderr, Options{ReportTimestamp: true})
-	})
-	return defaultLogger
+	dl := defaultLogger.Load()
+	if dl == nil {
+		defaultLoggerOnce.Do(func() {
+			defaultLogger.CompareAndSwap(
+				nil, NewWithOptions(os.Stderr, Options{ReportTimestamp: true}),
+			)
+		})
+		dl = defaultLogger.Load()
+	}
+	return dl
 }
 
 // SetDefault sets the default global logger.
 func SetDefault(logger *Logger) {
-	defaultLogger = logger
+	defaultLogger.Store(logger)
 }
 
 // New returns a new logger with the default options.

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -3,16 +3,34 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestDefaultRace(t *testing.T) {
+	l := Default()
+	t.Cleanup(func() {
+		SetDefault(l)
+	})
+
+	for i := 0; i < 2; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			SetDefault(New(io.Discard))
+			Default().Info("foo")
+		})
+	}
+}
 
 func TestGlobal(t *testing.T) {
 	var buf bytes.Buffer


### PR DESCRIPTION
This adds synchronisation primitives around all uses of the `defaultLogger`.

`atomic.Pointer` was introduced in Go 1.19. I see you have 1.19 in `.github/` and `go.mod`, but maybe you still try to be backwards compatible? If so, I can replace `atomic.Pointer` with `atomic.Value`.

**UPDATE**: I see now that in #111, on purpose we delay initialisation of the logger. Reading about [init in Effective Go] it looks like using `func init()` should work fine.

> [..] init is called after all the variable declarations in the package have evaluated their initializers, and those are evaluated only after all the imported packages have been initialized. 

(An alternative solution exists at e31f99cb but is more complicated imho. Most likely the problem with escape sequence during initialisation was because of the race within this package.)

[init in Effective Go]: https://go.dev/doc/effective_go#initialization

Fixes #121.