### PR TITLE
docs: Fixing broken links in the examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
 For those of you who are new to Go, check out
-[pkg.go.dev](https://https://pkg.go.dev/github.com/charmbracelet/log) to
+[pkg.go.dev](https://pkg.go.dev/github.com/charmbracelet/log) to
 view our library's API. From there, you can search the repo for more detailed
 usage examples for whichever functions match your use case.


### PR DESCRIPTION
Fixed Broken link in examples/README.md