### PR TITLE
change type of Level to int

### DIFF
--- a/level.go
+++ b/level.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Level is a logging level.
-type Level int32
+type Level int
 
 const (
 	// DebugLevel is the debug level.
@@ -22,7 +22,7 @@ const (
 	// FatalLevel is the fatal level.
 	FatalLevel Level = 12
 	// noLevel is used with log.Print.
-	noLevel Level = math.MaxInt32
+	noLevel Level = math.MaxInt
 )
 
 // String returns the string representation of the level.

--- a/logger.go
+++ b/logger.go
@@ -30,7 +30,7 @@ type Logger struct {
 
 	isDiscard uint32
 
-	level           int32
+	level           int64
 	prefix          string
 	timeFunc        TimeFunction
 	timeFormat      string
@@ -59,7 +59,7 @@ func (l *Logger) Log(level Level, msg interface{}, keyvals ...interface{}) {
 	}
 
 	// check if the level is allowed
-	if atomic.LoadInt32(&l.level) > int32(level) {
+	if atomic.LoadInt64(&l.level) > int64(level) {
 		return
 	}
 
@@ -234,7 +234,7 @@ func (l *Logger) GetLevel() Level {
 func (l *Logger) SetLevel(level Level) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	atomic.StoreInt32(&l.level, int32(level))
+	atomic.StoreInt64(&l.level, int64(level))
 }
 
 // GetPrefix returns the current prefix.

--- a/logger_121.go
+++ b/logger_121.go
@@ -23,7 +23,7 @@ const slogKindGroup = slog.KindGroup
 //
 // Implements slog.Handler.
 func (l *Logger) Enabled(_ context.Context, level slog.Level) bool {
-	return atomic.LoadInt32(&l.level) <= int32(level)
+	return atomic.LoadInt64(&l.level) <= int64(level)
 }
 
 // Handle handles the Record. It will only be called if Enabled returns true.

--- a/logger_no121.go
+++ b/logger_no121.go
@@ -24,7 +24,7 @@ const slogKindGroup = slog.KindGroup
 //
 // Implements slog.Handler.
 func (l *Logger) Enabled(_ context.Context, level slog.Level) bool {
-	return atomic.LoadInt32(&l.level) <= int32(level)
+	return atomic.LoadInt64(&l.level) <= int64(level)
 }
 
 // Handle handles the Record. It will only be called if Enabled returns true.

--- a/pkg.go
+++ b/pkg.go
@@ -52,7 +52,7 @@ func NewWithOptions(w io.Writer, o Options) *Logger {
 		b:               bytes.Buffer{},
 		mu:              &sync.RWMutex{},
 		helpers:         &sync.Map{},
-		level:           int32(o.Level),
+		level:           int64(o.Level),
 		reportTimestamp: o.ReportTimestamp,
 		reportCaller:    o.ReportCaller,
 		prefix:          o.Prefix,


### PR DESCRIPTION
_Marking this as draft to gather feedback_

The `Level` type (`int32`) is currently slightly incompatible with stdlib's `slog.Level` type, which is an `int`. This means it's impossible to safely cast a `slog.Level` to a `charmlog.Level`, without risking an overflow. (Practically speaking, that's very unlikely, but try telling that to the linter 😆).

This PR changes `type Level int32` to `type Level int` and updates some places where `atomic.StoreInt32` was called to `atomic.StoreInt64`.

It's entirely possible that this change isn't safe, and that there's already enough code out there that expects `charmlog.Level` to be an `int32` that this would break enough folks not to be worth it.

But, if this change is doable, it would make it slightly easier for code that uses this package to interoperate with stdlib's `slog`.