### PR TITLE
fix: ensure we recognize errors as slog.AnyValue

### DIFF
--- a/json.go
+++ b/json.go
@@ -88,7 +88,13 @@ func (l *Logger) writeSlogValue(jw *jsonWriter, v slogValue) {
 		}
 		jw.end()
 	default:
-		jw.objectValue(v.Any())
+		a := v.Any()
+		_, jm := a.(json.Marshaler)
+		if err, ok := a.(error); ok && !jm {
+			jw.objectValue(err.Error())
+		} else {
+			jw.objectValue(a)
+		}
 	}
 }
 

--- a/json_test.go
+++ b/json_test.go
@@ -113,6 +113,13 @@ func TestJson(t *testing.T) {
 			kvs:      []interface{}{"map", map[string]string{"a": "b", "foo": "bar"}},
 			f:        l.Info,
 		},
+		{
+			name:     "slog any value error type",
+			expected: "{\"level\":\"info\",\"msg\":\"info\",\"error\":\"error message\"}\n",
+			msg:      "info",
+			kvs:      []interface{}{"error", slogAnyValue(fmt.Errorf("error message"))},
+			f:        l.Info,
+		},
 	}
 	for _, c := range cases {
 		buf.Reset()

--- a/logger_121.go
+++ b/logger_121.go
@@ -17,6 +17,8 @@ type (
 	slogLogValuer = slog.LogValuer
 )
 
+var slogAnyValue = slog.AnyValue
+
 const slogKindGroup = slog.KindGroup
 
 // Enabled reports whether the logger is enabled for the given level.

--- a/logger_no121.go
+++ b/logger_no121.go
@@ -18,6 +18,8 @@ type (
 	slogLogValuer = slog.LogValuer
 )
 
+var slogAnyValue = slog.AnyValue
+
 const slogKindGroup = slog.KindGroup
 
 // Enabled reports whether the logger is enabled for the given level.


### PR DESCRIPTION
We need to type check any value to see if it is an error. While doing so, we also need to check if it doesn't have a json.Marshaler interface to avoid overwriting the error message with the marshaled value.

Fixes: https://github.com/charmbracelet/log/issues/170
