### PR TITLE
feat: adjust default style max width to 5

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -53,27 +53,27 @@ func DefaultStyles() *Styles {
 			DebugLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(DebugLevel.String())).
 				Bold(true).
-				MaxWidth(4).
+				MaxWidth(5).
 				Foreground(lipgloss.Color("63")),
 			InfoLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(InfoLevel.String())).
 				Bold(true).
-				MaxWidth(4).
+				MaxWidth(5).
 				Foreground(lipgloss.Color("86")),
 			WarnLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(WarnLevel.String())).
 				Bold(true).
-				MaxWidth(4).
+				MaxWidth(5).
 				Foreground(lipgloss.Color("192")),
 			ErrorLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(ErrorLevel.String())).
 				Bold(true).
-				MaxWidth(4).
+				MaxWidth(5).
 				Foreground(lipgloss.Color("204")),
 			FatalLevel: lipgloss.NewStyle().
 				SetString(strings.ToUpper(FatalLevel.String())).
 				Bold(true).
-				MaxWidth(4).
+				MaxWidth(5).
 				Foreground(lipgloss.Color("134")),
 		},
 		Keys:   map[string]lipgloss.Style{},


### PR DESCRIPTION
### Describe your changes

- The logger that `log.New` creates imposes a maximum width on the level string of 4 which means `ERROR` and `DEBUG` get cut off to `ERRO` and `DEBU` which looks odd. Here is a practical example of a logger using the default style:

```console
# Atmos binary using log

❯ atmos list components
DEBU Set logs-level=debug logs-file=/dev/stderr
DEBU 'atmos.yaml' CLI config was not found paths="system dir, home dir, current dir, ENV vars"
DEBU Refer to https://atmos.tools/cli/configuration for details on how to configure 'atmos.yaml'
DEBU Using the default CLI config
DEBU processStoreConfig atmosConfig.StoresConfig=map[]
DEBU 'atmos.yaml' CLI config was not found paths="system dir, home dir, current dir, ENV vars"
DEBU Refer to https://atmos.tools/cli/configuration for details on how to configure 'atmos.yaml'
DEBU Using the default CLI config
DEBU processStoreConfig atmosConfig.StoresConfig=map[]
```

### Related issue/discussion: #164 

### Checklist before requesting a review

- [X] I have read `CONTRIBUTING.md`
- [X] I have performed a self-review of my code