### PR TITLE
feat: add optional `skip` argument to `Helper` function

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -142,8 +142,16 @@ func (l *Logger) handle(level Level, ts time.Time, frames []runtime.Frame, msg i
 // Helper marks the calling function as a helper
 // and skips it for source location information.
 // It's the equivalent of testing.TB.Helper().
-func (l *Logger) Helper() {
-	l.helper(1)
+//
+// It takes an optional argument skip,
+// which is the depth of the call stack that should be skipped.
+// In most cases you should omit providing it and it will default to 1.
+func (l *Logger) Helper(skip ...int) {
+	if len(skip) > 0 {
+		l.helper(skip[0])
+	} else {
+		l.helper(1)
+	}
 }
 
 func (l *Logger) helper(skip int) {

--- a/pkg.go
+++ b/pkg.go
@@ -167,8 +167,16 @@ func WithPrefix(prefix string) *Logger {
 // Helper marks the calling function as a helper
 // and skips it for source location information.
 // It's the equivalent of testing.TB.Helper().
-func Helper() {
-	Default().helper(1)
+//
+// It takes an optional argument skip,
+// which is the depth of the call stack that should be skipped.
+// In most cases you should omit providing it and it will default to 1.
+func Helper(skip ...int) {
+	if len(skip) > 0 {
+		Default().helper(skip[0])
+	} else {
+		Default().helper(1)
+	}
 }
 
 // Log logs a message with the given level.

--- a/text_test.go
+++ b/text_test.go
@@ -53,7 +53,7 @@ func TestTextCaller(t *testing.T) {
 		},
 		{
 			name:     "helper caller",
-			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+58),
+			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+71),
 			msg:      "info",
 			kvs:      nil,
 			f: func(msg interface{}, kvs ...interface{}) {
@@ -76,7 +76,7 @@ func TestTextCaller(t *testing.T) {
 		},
 		{
 			name:     "double nested helper caller",
-			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+58),
+			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+71),
 			msg:      "info",
 			kvs:      nil,
 			f: func(msg interface{}, kvs ...interface{}) {
@@ -86,6 +86,19 @@ func TestTextCaller(t *testing.T) {
 					logger.Info(msg, kvs...)
 				}
 				fun(msg, kvs...)
+			},
+		},
+		{
+			name:     "encapsulated helper caller",
+			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+71),
+			msg:      "info",
+			kvs:      nil,
+			f: func(msg interface{}, kvs ...interface{}) {
+				encapsulatedHelper := func() {
+					logger.Helper(2)
+				}
+				encapsulatedHelper()
+				logger.Info(msg, kvs...)
 			},
 		},
 	}


### PR DESCRIPTION
# The problem

The current `Helper` function is hardcoded to only skip the immediate function that called it. This makes it really unergonomic to use in an abstraction.

I have an abstraction type which provides a bunch of convenience methods, e.g. extracts known values from `context.Context` and passes them as attributes to the various log functions. This abstraction also manages multiple different instances of `Logger` under the hood. It all works quite well, except when it comes to `Helper`.

## Broken abstraction

```go
func AbstractedHelper() {
    // Calling the Helper function on these Logger instances
    // will just mark AbstractedHelper for skipping.
    loggerA.Helper()
    loggerB.Helper()
}

func example() {
    common()
}

func common() {
    AbstractedHelper()
    Info("Hello") // Incorrectly prints this line as the source
}
```

## Working but unergonomic abstraction

```go
func AbstractedHelper() []func() {
    // Don't call the functions yet, just return them.
    return []func(){loggerA.Helper, loggerB.Helper}
}

func example() {
    common() // Correctly prints this line as the source
}

func common() {
    for _, helper := range AbstractedHelper() {
        helper()
    }
    Info("Hello")
}
```

# The solution

The internal `helper` function already takes a `skip` argument that would solve this issue. The public function doesn't yet expose this and that is exactly what this PR does.

In order to achieve backwards compatibility, the `skip` argument will be optional by making the public `Helper` a variadic function.

## Ergonomic abstraction achieved

```go
func AbstractedHelper() {
    // We tell Helper to also skip the abstraction function
    loggerA.Helper(2)
    loggerB.Helper(2)
}

func example() {
    common() // Correctly prints this line as the source
}

func common() {
    AbstractedHelper()
    Info("Hello")
}
```