### PR TITLE
change interface{} to any

### DIFF
--- a/json.go
+++ b/json.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func (l *Logger) jsonFormatter(keyvals ...interface{}) {
+func (l *Logger) jsonFormatter(keyvals ...any) {
 	jw := &jsonWriter{w: &l.b}
 	jw.start()
 

--- a/json_test.go
+++ b/json_test.go
@@ -19,8 +19,8 @@ func TestJson(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		kvs      []interface{}
-		f        func(msg interface{}, kvs ...interface{})
+		kvs      []any
+		f        func(msg any, kvs ...any)
 	}{
 		{
 			name:     "default logger info with timestamp",
@@ -54,70 +54,70 @@ func TestJson(t *testing.T) {
 			name:     "multiline kvs",
 			expected: "{\"level\":\"error\",\"msg\":\"info\",\"multiline\":\"info\\ninfo\"}\n",
 			msg:      "info",
-			kvs:      []interface{}{"multiline", "info\ninfo"},
+			kvs:      []any{"multiline", "info\ninfo"},
 			f:        l.Error,
 		},
 		{
 			name:     "odd number of kvs",
 			expected: "{\"level\":\"error\",\"msg\":\"info\",\"foo\":\"bar\",\"baz\":\"missing value\"}\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", "bar", "baz"},
+			kvs:      []any{"foo", "bar", "baz"},
 			f:        l.Error,
 		},
 		{
 			name:     "error field",
 			expected: "{\"level\":\"error\",\"msg\":\"info\",\"error\":\"error message\"}\n",
 			msg:      "info",
-			kvs:      []interface{}{"error", errors.New("error message")},
+			kvs:      []any{"error", errors.New("error message")},
 			f:        l.Error,
 		},
 		{
 			name:     "struct field",
 			expected: "{\"level\":\"info\",\"msg\":\"info\",\"struct\":{}}\n",
 			msg:      "info",
-			kvs:      []interface{}{"struct", struct{ foo string }{foo: "bar"}},
+			kvs:      []any{"struct", struct{ foo string }{foo: "bar"}},
 			f:        l.Info,
 		},
 		{
 			name:     "slice field",
 			expected: "{\"level\":\"info\",\"msg\":\"info\",\"slice\":[1,2,3]}\n",
 			msg:      "info",
-			kvs:      []interface{}{"slice", []int{1, 2, 3}},
+			kvs:      []any{"slice", []int{1, 2, 3}},
 			f:        l.Info,
 		},
 		{
 			name:     "slice of structs",
 			expected: "{\"level\":\"info\",\"msg\":\"info\",\"slice\":[{},{}]}\n",
 			msg:      "info",
-			kvs:      []interface{}{"slice", []struct{ foo string }{{foo: "bar"}, {foo: "baz"}}},
+			kvs:      []any{"slice", []struct{ foo string }{{foo: "bar"}, {foo: "baz"}}},
 			f:        l.Info,
 		},
 		{
 			name:     "slice of strings",
 			expected: "{\"level\":\"info\",\"msg\":\"info\",\"slice\":[\"foo\",\"bar\"]}\n",
 			msg:      "info",
-			kvs:      []interface{}{"slice", []string{"foo", "bar"}},
+			kvs:      []any{"slice", []string{"foo", "bar"}},
 			f:        l.Info,
 		},
 		{
 			name:     "slice of errors",
 			expected: "{\"level\":\"info\",\"msg\":\"info\",\"slice\":[{},{}]}\n",
 			msg:      "info",
-			kvs:      []interface{}{"slice", []error{errors.New("error message1"), errors.New("error message2")}},
+			kvs:      []any{"slice", []error{errors.New("error message1"), errors.New("error message2")}},
 			f:        l.Info,
 		},
 		{
 			name:     "map of strings",
 			expected: "{\"level\":\"info\",\"msg\":\"info\",\"map\":{\"a\":\"b\",\"foo\":\"bar\"}}\n",
 			msg:      "info",
-			kvs:      []interface{}{"map", map[string]string{"a": "b", "foo": "bar"}},
+			kvs:      []any{"map", map[string]string{"a": "b", "foo": "bar"}},
 			f:        l.Info,
 		},
 		{
 			name:     "slog any value error type",
 			expected: "{\"level\":\"info\",\"msg\":\"info\",\"error\":\"error message\"}\n",
 			msg:      "info",
-			kvs:      []interface{}{"error", slogAnyValue(fmt.Errorf("error message"))},
+			kvs:      []any{"error", slogAnyValue(fmt.Errorf("error message"))},
 			f:        l.Info,
 		},
 	}
@@ -141,9 +141,9 @@ func TestJsonCaller(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		kvs      []interface{}
+		kvs      []any
 
-		f func(msg interface{}, kvs ...interface{})
+		f func(msg any, kvs ...any)
 	}{
 		{
 			name:     "simple caller",
@@ -157,7 +157,7 @@ func TestJsonCaller(t *testing.T) {
 			expected: fmt.Sprintf("{\"level\":\"info\",\"caller\":\"log/%s:%d\",\"msg\":\"info\"}\n", filepath.Base(file), line+30),
 			msg:      "info",
 			kvs:      nil,
-			f: func(msg interface{}, kvs ...interface{}) {
+			f: func(msg any, kvs ...any) {
 				l.Helper()
 				l.Info(msg, kvs...)
 			},

--- a/logfmt.go
+++ b/logfmt.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logfmt/logfmt"
 )
 
-func (l *Logger) logfmtFormatter(keyvals ...interface{}) {
+func (l *Logger) logfmtFormatter(keyvals ...any) {
 	e := logfmt.NewEncoder(&l.b)
 
 	for i := 0; i < len(keyvals); i += 2 {

--- a/logfmt_test.go
+++ b/logfmt_test.go
@@ -16,8 +16,8 @@ func TestLogfmt(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		kvs      []interface{}
-		f        func(msg interface{}, kvs ...interface{})
+		kvs      []any
+		f        func(msg any, kvs ...any)
 	}{
 		{
 			name:     "simple",
@@ -37,14 +37,14 @@ func TestLogfmt(t *testing.T) {
 			name:     "message with keyvals",
 			expected: "level=info msg=info foo=bar\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", "bar"},
+			kvs:      []any{"foo", "bar"},
 			f:        l.Info,
 		},
 		{
 			name:     "message with multiline keyvals",
 			expected: "level=info msg=info foo=\"bar\\nbaz\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", "bar\nbaz"},
+			kvs:      []any{"foo", "bar\nbaz"},
 			f:        l.Info,
 		},
 		{
@@ -58,63 +58,63 @@ func TestLogfmt(t *testing.T) {
 			name:     "message with error",
 			expected: "level=info msg=info err=\"foo: bar\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"err", errors.New("foo: bar")},
+			kvs:      []any{"err", errors.New("foo: bar")},
 			f:        l.Info,
 		},
 		{
 			name:     "odd number of keyvals",
 			expected: "level=info msg=info foo=bar baz=\"missing value\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", "bar", "baz"},
+			kvs:      []any{"foo", "bar", "baz"},
 			f:        l.Info,
 		},
 		{
 			name:     "struct field",
 			expected: "level=info msg=info foo=\"{bar:foo bar}\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", struct{ bar string }{"foo bar"}},
+			kvs:      []any{"foo", struct{ bar string }{"foo bar"}},
 			f:        l.Info,
 		},
 		{
 			name:     "multiple struct fields",
 			expected: "level=info msg=info foo={bar:baz} foo2={bar:baz}\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", struct{ bar string }{"baz"}, "foo2", struct{ bar string }{"baz"}},
+			kvs:      []any{"foo", struct{ bar string }{"baz"}, "foo2", struct{ bar string }{"baz"}},
 			f:        l.Info,
 		},
 		{
 			name:     "slice of structs",
 			expected: "level=info msg=info foo=\"[{bar:baz} {bar:baz}]\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", []struct{ bar string }{{"baz"}, {"baz"}}},
+			kvs:      []any{"foo", []struct{ bar string }{{"baz"}, {"baz"}}},
 			f:        l.Info,
 		},
 		{
 			name:     "slice of strings",
 			expected: "level=info msg=info foo=\"[bar baz]\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", []string{"bar", "baz"}},
+			kvs:      []any{"foo", []string{"bar", "baz"}},
 			f:        l.Info,
 		},
 		{
 			name:     "slice of errors",
 			expected: "level=info msg=info foo=\"[error1 error2]\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", []error{errors.New("error1"), errors.New("error2")}},
+			kvs:      []any{"foo", []error{errors.New("error1"), errors.New("error2")}},
 			f:        l.Info,
 		},
 		{
 			name:     "map of strings",
 			expected: "level=info msg=info foo=map[bar:baz]\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", map[string]string{"bar": "baz"}},
+			kvs:      []any{"foo", map[string]string{"bar": "baz"}},
 			f:        l.Info,
 		},
 		{
 			name:     "map with interface",
 			expected: "level=info msg=info foo=map[bar:baz]\n",
 			msg:      "info",
-			kvs:      []interface{}{"foo", map[string]interface{}{"bar": "baz"}},
+			kvs:      []any{"foo", map[string]any{"bar": "baz"}},
 			f:        l.Info,
 		},
 	}

--- a/logger.go
+++ b/logger.go
@@ -41,19 +41,19 @@ type Logger struct {
 	reportCaller    bool
 	reportTimestamp bool
 
-	fields []interface{}
+	fields []any
 
 	helpers *sync.Map
 	styles  *Styles
 }
 
 // Logf logs a message with formatting.
-func (l *Logger) Logf(level Level, format string, args ...interface{}) {
+func (l *Logger) Logf(level Level, format string, args ...any) {
 	l.Log(level, fmt.Sprintf(format, args...))
 }
 
 // Log logs the given message with the given keyvals for the given level.
-func (l *Logger) Log(level Level, msg interface{}, keyvals ...interface{}) {
+func (l *Logger) Log(level Level, msg any, keyvals ...any) {
 	if atomic.LoadUint32(&l.isDiscard) != 0 {
 		return
 	}
@@ -81,8 +81,8 @@ func (l *Logger) Log(level Level, msg interface{}, keyvals ...interface{}) {
 	l.handle(level, l.timeFunc(time.Now()), []runtime.Frame{frame}, msg, keyvals...)
 }
 
-func (l *Logger) handle(level Level, ts time.Time, frames []runtime.Frame, msg interface{}, keyvals ...interface{}) {
-	var kvs []interface{}
+func (l *Logger) handle(level Level, ts time.Time, frames []runtime.Frame, msg any, keyvals ...any) {
+	var kvs []any
 	if l.reportTimestamp && !ts.IsZero() {
 		kvs = append(kvs, TimestampKey, ts)
 	}
@@ -327,7 +327,7 @@ func (l *Logger) SetStyles(s *Styles) {
 }
 
 // With returns a new logger with the given keyvals added.
-func (l *Logger) With(keyvals ...interface{}) *Logger {
+func (l *Logger) With(keyvals ...any) *Logger {
 	var st Styles
 	l.mu.Lock()
 	sl := *l
@@ -336,7 +336,7 @@ func (l *Logger) With(keyvals ...interface{}) *Logger {
 	sl.b = bytes.Buffer{}
 	sl.mu = &sync.RWMutex{}
 	sl.helpers = &sync.Map{}
-	sl.fields = append(make([]interface{}, 0, len(l.fields)+len(keyvals)), l.fields...)
+	sl.fields = append(make([]any, 0, len(l.fields)+len(keyvals)), l.fields...)
 	sl.fields = append(sl.fields, keyvals...)
 	sl.styles = &st
 	return &sl
@@ -350,63 +350,63 @@ func (l *Logger) WithPrefix(prefix string) *Logger {
 }
 
 // Debug prints a debug message.
-func (l *Logger) Debug(msg interface{}, keyvals ...interface{}) {
+func (l *Logger) Debug(msg any, keyvals ...any) {
 	l.Log(DebugLevel, msg, keyvals...)
 }
 
 // Info prints an info message.
-func (l *Logger) Info(msg interface{}, keyvals ...interface{}) {
+func (l *Logger) Info(msg any, keyvals ...any) {
 	l.Log(InfoLevel, msg, keyvals...)
 }
 
 // Warn prints a warning message.
-func (l *Logger) Warn(msg interface{}, keyvals ...interface{}) {
+func (l *Logger) Warn(msg any, keyvals ...any) {
 	l.Log(WarnLevel, msg, keyvals...)
 }
 
 // Error prints an error message.
-func (l *Logger) Error(msg interface{}, keyvals ...interface{}) {
+func (l *Logger) Error(msg any, keyvals ...any) {
 	l.Log(ErrorLevel, msg, keyvals...)
 }
 
 // Fatal prints a fatal message and exits.
-func (l *Logger) Fatal(msg interface{}, keyvals ...interface{}) {
+func (l *Logger) Fatal(msg any, keyvals ...any) {
 	l.Log(FatalLevel, msg, keyvals...)
 	os.Exit(1)
 }
 
 // Print prints a message with no level.
-func (l *Logger) Print(msg interface{}, keyvals ...interface{}) {
+func (l *Logger) Print(msg any, keyvals ...any) {
 	l.Log(noLevel, msg, keyvals...)
 }
 
 // Debugf prints a debug message with formatting.
-func (l *Logger) Debugf(format string, args ...interface{}) {
+func (l *Logger) Debugf(format string, args ...any) {
 	l.Log(DebugLevel, fmt.Sprintf(format, args...))
 }
 
 // Infof prints an info message with formatting.
-func (l *Logger) Infof(format string, args ...interface{}) {
+func (l *Logger) Infof(format string, args ...any) {
 	l.Log(InfoLevel, fmt.Sprintf(format, args...))
 }
 
 // Warnf prints a warning message with formatting.
-func (l *Logger) Warnf(format string, args ...interface{}) {
+func (l *Logger) Warnf(format string, args ...any) {
 	l.Log(WarnLevel, fmt.Sprintf(format, args...))
 }
 
 // Errorf prints an error message with formatting.
-func (l *Logger) Errorf(format string, args ...interface{}) {
+func (l *Logger) Errorf(format string, args ...any) {
 	l.Log(ErrorLevel, fmt.Sprintf(format, args...))
 }
 
 // Fatalf prints a fatal message with formatting and exits.
-func (l *Logger) Fatalf(format string, args ...interface{}) {
+func (l *Logger) Fatalf(format string, args ...any) {
 	l.Log(FatalLevel, fmt.Sprintf(format, args...))
 	os.Exit(1)
 }
 
 // Printf prints a message with no level and formatting.
-func (l *Logger) Printf(format string, args ...interface{}) {
+func (l *Logger) Printf(format string, args ...any) {
 	l.Log(noLevel, fmt.Sprintf(format, args...))
 }

--- a/logger_121.go
+++ b/logger_121.go
@@ -36,7 +36,7 @@ func (l *Logger) Handle(ctx context.Context, record slog.Record) error {
 		return nil
 	}
 
-	fields := make([]interface{}, 0, record.NumAttrs()*2)
+	fields := make([]any, 0, record.NumAttrs()*2)
 	record.Attrs(func(a slog.Attr) bool {
 		fields = append(fields, a.Key, a.Value)
 		return true
@@ -52,7 +52,7 @@ func (l *Logger) Handle(ctx context.Context, record slog.Record) error {
 //
 // Implements slog.Handler.
 func (l *Logger) WithAttrs(attrs []slog.Attr) slog.Handler {
-	fields := make([]interface{}, 0, len(attrs)*2)
+	fields := make([]any, 0, len(attrs)*2)
 	for _, attr := range attrs {
 		fields = append(fields, attr.Key, attr.Value)
 	}

--- a/logger_121_test.go
+++ b/logger_121_test.go
@@ -195,7 +195,7 @@ func TestSlogAttr(t *testing.T) {
 	cases := []struct {
 		name     string
 		expected string
-		kvs      []interface{}
+		kvs      []any
 	}{
 		{
 			name:     "any",

--- a/logger_no121.go
+++ b/logger_no121.go
@@ -33,7 +33,7 @@ func (l *Logger) Enabled(_ context.Context, level slog.Level) bool {
 //
 // Implements slog.Handler.
 func (l *Logger) Handle(_ context.Context, record slog.Record) error {
-	fields := make([]interface{}, 0, record.NumAttrs()*2)
+	fields := make([]any, 0, record.NumAttrs()*2)
 	record.Attrs(func(a slog.Attr) bool {
 		fields = append(fields, a.Key, a.Value)
 		return true
@@ -49,7 +49,7 @@ func (l *Logger) Handle(_ context.Context, record slog.Record) error {
 //
 // Implements slog.Handler.
 func (l *Logger) WithAttrs(attrs []slog.Attr) slog.Handler {
-	fields := make([]interface{}, 0, len(attrs)*2)
+	fields := make([]any, 0, len(attrs)*2)
 	for _, attr := range attrs {
 		fields = append(fields, attr.Key, attr.Value)
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -18,8 +18,8 @@ func TestSubLogger(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		fields   []interface{}
-		kvs      []interface{}
+		fields   []any
+		kvs      []any
 	}{
 		{
 			name:     "sub logger nil fields",
@@ -32,15 +32,15 @@ func TestSubLogger(t *testing.T) {
 			name:     "sub logger info",
 			expected: "INFO info foo=bar\n",
 			msg:      "info",
-			fields:   []interface{}{"foo", "bar"},
+			fields:   []any{"foo", "bar"},
 			kvs:      nil,
 		},
 		{
 			name:     "sub logger info with kvs",
 			expected: "INFO info foo=bar foobar=baz\n",
 			msg:      "info",
-			fields:   []interface{}{"foo", "bar"},
-			kvs:      []interface{}{"foobar", "baz"},
+			fields:   []any{"foo", "bar"},
+			kvs:      []any{"foobar", "baz"},
 		},
 		{
 			name:     "emoji",
@@ -95,35 +95,35 @@ func TestLogFormatter(t *testing.T) {
 	cases := []struct {
 		name     string
 		format   string
-		args     []interface{}
-		fun      func(string, ...interface{})
+		args     []any
+		fun      func(string, ...any)
 		expected string
 	}{
 		{
 			name:     "info format",
 			format:   "%s %s",
-			args:     []interface{}{"foo", "bar"},
+			args:     []any{"foo", "bar"},
 			fun:      l.Infof,
 			expected: "INFO foo bar\n",
 		},
 		{
 			name:     "debug format",
 			format:   "%s %s",
-			args:     []interface{}{"foo", "bar"},
+			args:     []any{"foo", "bar"},
 			fun:      l.Debugf,
 			expected: "DEBU foo bar\n",
 		},
 		{
 			name:     "warn format",
 			format:   "%s %s",
-			args:     []interface{}{"foo", "bar"},
+			args:     []any{"foo", "bar"},
 			fun:      l.Warnf,
 			expected: "WARN foo bar\n",
 		},
 		{
 			name:     "error format",
 			format:   "%s %s",
-			args:     []interface{}{"foo", "bar"},
+			args:     []any{"foo", "bar"},
 			fun:      l.Errorf,
 			expected: "ERRO foo bar\n",
 		},
@@ -144,8 +144,8 @@ func TestEmptyMessage(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		fields   []interface{}
-		kvs      []interface{}
+		fields   []any
+		kvs      []any
 	}{
 		{
 			name:     "empty message nil fields",
@@ -158,15 +158,15 @@ func TestEmptyMessage(t *testing.T) {
 			name:     "empty message with fields",
 			expected: "INFO foo=bar\n",
 			msg:      "",
-			fields:   []interface{}{"foo", "bar"},
+			fields:   []any{"foo", "bar"},
 			kvs:      nil,
 		},
 		{
 			name:     "empty message with fields & kvs",
 			expected: "INFO foo=bar foobar=baz\n",
 			msg:      "",
-			fields:   []interface{}{"foo", "bar"},
-			kvs:      []interface{}{"foobar", "baz"},
+			fields:   []any{"foo", "bar"},
+			kvs:      []any{"foobar", "baz"},
 		},
 	}
 	for _, c := range cases {
@@ -219,7 +219,7 @@ func TestLogWithRaceCondition(t *testing.T) {
 
 			var done sync.WaitGroup
 
-			longArgs := make([]interface{}, 0, 1000)
+			longArgs := make([]any, 0, 1000)
 			for i := 0; i < 1000; i++ {
 				longArgs = append(longArgs, fmt.Sprintf("arg%d", i), fmt.Sprintf("val%d", i))
 			}

--- a/options.go
+++ b/options.go
@@ -55,7 +55,7 @@ type Options struct {
 	// CallerOffset is the caller format for the logger. The default is 0.
 	CallerOffset int
 	// Fields is the fields for the logger. The default is no fields.
-	Fields []interface{}
+	Fields []any
 	// Formatter is the formatter for the logger. The default is TextFormatter.
 	Formatter Formatter
 }

--- a/options_test.go
+++ b/options_test.go
@@ -13,13 +13,13 @@ func TestOptions(t *testing.T) {
 	opts := Options{
 		Level:        ErrorLevel,
 		ReportCaller: true,
-		Fields:       []interface{}{"foo", "bar"},
+		Fields:       []any{"foo", "bar"},
 	}
 	logger := NewWithOptions(io.Discard, opts)
 	require.Equal(t, ErrorLevel, logger.GetLevel())
 	require.True(t, logger.reportCaller)
 	require.False(t, logger.reportTimestamp)
-	require.Equal(t, []interface{}{"foo", "bar"}, logger.fields)
+	require.Equal(t, []any{"foo", "bar"}, logger.fields)
 	require.Equal(t, TextFormatter, logger.formatter)
 	require.Equal(t, DefaultTimeFormat, logger.timeFormat)
 	require.NotNil(t, logger.timeFunc)

--- a/pkg.go
+++ b/pkg.go
@@ -155,7 +155,7 @@ func GetPrefix() string {
 }
 
 // With returns a new logger with the given keyvals.
-func With(keyvals ...interface{}) *Logger {
+func With(keyvals ...any) *Logger {
 	return Default().With(keyvals...)
 }
 
@@ -172,74 +172,74 @@ func Helper() {
 }
 
 // Log logs a message with the given level.
-func Log(level Level, msg interface{}, keyvals ...interface{}) {
+func Log(level Level, msg any, keyvals ...any) {
 	Default().Log(level, msg, keyvals...)
 }
 
 // Debug logs a debug message.
-func Debug(msg interface{}, keyvals ...interface{}) {
+func Debug(msg any, keyvals ...any) {
 	Default().Log(DebugLevel, msg, keyvals...)
 }
 
 // Info logs an info message.
-func Info(msg interface{}, keyvals ...interface{}) {
+func Info(msg any, keyvals ...any) {
 	Default().Log(InfoLevel, msg, keyvals...)
 }
 
 // Warn logs a warning message.
-func Warn(msg interface{}, keyvals ...interface{}) {
+func Warn(msg any, keyvals ...any) {
 	Default().Log(WarnLevel, msg, keyvals...)
 }
 
 // Error logs an error message.
-func Error(msg interface{}, keyvals ...interface{}) {
+func Error(msg any, keyvals ...any) {
 	Default().Log(ErrorLevel, msg, keyvals...)
 }
 
 // Fatal logs a fatal message and exit.
-func Fatal(msg interface{}, keyvals ...interface{}) {
+func Fatal(msg any, keyvals ...any) {
 	Default().Log(FatalLevel, msg, keyvals...)
 	os.Exit(1)
 }
 
 // Print logs a message with no level.
-func Print(msg interface{}, keyvals ...interface{}) {
+func Print(msg any, keyvals ...any) {
 	Default().Log(noLevel, msg, keyvals...)
 }
 
 // Logf logs a message with formatting and level.
-func Logf(level Level, format string, args ...interface{}) {
+func Logf(level Level, format string, args ...any) {
 	Default().Logf(level, format, args...)
 }
 
 // Debugf logs a debug message with formatting.
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	Default().Log(DebugLevel, fmt.Sprintf(format, args...))
 }
 
 // Infof logs an info message with formatting.
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	Default().Log(InfoLevel, fmt.Sprintf(format, args...))
 }
 
 // Warnf logs a warning message with formatting.
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	Default().Log(WarnLevel, fmt.Sprintf(format, args...))
 }
 
 // Errorf logs an error message with formatting.
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	Default().Log(ErrorLevel, fmt.Sprintf(format, args...))
 }
 
 // Fatalf logs a fatal message with formatting and exit.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	Default().Log(FatalLevel, fmt.Sprintf(format, args...))
 	os.Exit(1)
 }
 
 // Printf logs a message with formatting and no level.
-func Printf(format string, args ...interface{}) {
+func Printf(format string, args ...any) {
 	Default().Log(noLevel, fmt.Sprintf(format, args...))
 }
 

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -40,8 +40,8 @@ func TestGlobal(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		kvs      []interface{}
-		f        func(msg interface{}, kvs ...interface{})
+		kvs      []any
+		f        func(msg any, kvs ...any)
 	}{
 		{
 			name:     "default logger info with timestamp",

--- a/text.go
+++ b/text.go
@@ -62,7 +62,7 @@ const (
 )
 
 var bufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(strings.Builder)
 	},
 }
@@ -164,7 +164,7 @@ func writeSpace(w io.Writer, first bool) {
 	}
 }
 
-func (l *Logger) textFormatter(keyvals ...interface{}) {
+func (l *Logger) textFormatter(keyvals ...any) {
 	st := l.styles
 	lenKeyvals := len(keyvals)
 

--- a/text_test.go
+++ b/text_test.go
@@ -39,15 +39,15 @@ func TestTextCaller(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		kvs      []interface{}
-		f        func(msg interface{}, kvs ...interface{})
+		kvs      []any
+		f        func(msg any, kvs ...any)
 	}{
 		{
 			name:     "simple caller",
 			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+14),
 			msg:      "info",
 			kvs:      nil,
-			f: func(msg interface{}, kvs ...interface{}) {
+			f: func(msg any, kvs ...any) {
 				logger.Info(msg, kvs...)
 			},
 		},
@@ -56,7 +56,7 @@ func TestTextCaller(t *testing.T) {
 			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+58),
 			msg:      "info",
 			kvs:      nil,
-			f: func(msg interface{}, kvs ...interface{}) {
+			f: func(msg any, kvs ...any) {
 				logger.Helper()
 				logger.Info(msg, kvs...)
 			},
@@ -66,8 +66,8 @@ func TestTextCaller(t *testing.T) {
 			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+37),
 			msg:      "info",
 			kvs:      nil,
-			f: func(msg interface{}, kvs ...interface{}) {
-				fun := func(msg interface{}, kvs ...interface{}) {
+			f: func(msg any, kvs ...any) {
+				fun := func(msg any, kvs ...any) {
 					logger.Helper()
 					logger.Info(msg, kvs...)
 				}
@@ -79,9 +79,9 @@ func TestTextCaller(t *testing.T) {
 			expected: fmt.Sprintf("INFO <log/%s:%d> info\n", filepath.Base(file), line+58),
 			msg:      "info",
 			kvs:      nil,
-			f: func(msg interface{}, kvs ...interface{}) {
+			f: func(msg any, kvs ...any) {
 				logger.Helper()
-				fun := func(msg interface{}, kvs ...interface{}) {
+				fun := func(msg any, kvs ...any) {
 					logger.Helper()
 					logger.Info(msg, kvs...)
 				}
@@ -105,8 +105,8 @@ func TestTextLogger(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		kvs      []interface{}
-		f        func(msg interface{}, kvs ...interface{})
+		kvs      []any
+		f        func(msg any, kvs ...any)
 	}{
 		{
 			name:     "simple message",
@@ -126,77 +126,77 @@ func TestTextLogger(t *testing.T) {
 			name:     "message with keyvals",
 			expected: "INFO info key1=val1 key2=val2\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", "val1", "key2", "val2"},
+			kvs:      []any{"key1", "val1", "key2", "val2"},
 			f:        logger.Info,
 		},
 		{
 			name:     "error message with keyvals",
 			expected: "ERRO info key1=val1 key2=val2\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", "val1", "key2", "val2"},
+			kvs:      []any{"key1", "val1", "key2", "val2"},
 			f:        logger.Error,
 		},
 		{
 			name:     "error message with multiline",
 			expected: "ERRO info\n  key1=\n  │ val1\n  │ val2\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", "val1\nval2"},
+			kvs:      []any{"key1", "val1\nval2"},
 			f:        logger.Error,
 		},
 		{
 			name:     "odd number of keyvals",
 			expected: "ERRO info key1=val1 key2=val2 key3=\"missing value\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", "val1", "key2", "val2", "key3"},
+			kvs:      []any{"key1", "val1", "key2", "val2", "key3"},
 			f:        logger.Error,
 		},
 		{
 			name:     "error field",
 			expected: "ERRO info key1=\"error value\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", errors.New("error value")},
+			kvs:      []any{"key1", errors.New("error value")},
 			f:        logger.Error,
 		},
 		{
 			name:     "struct field",
 			expected: "ERRO info key1={foo:bar}\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", struct{ foo string }{foo: "bar"}},
+			kvs:      []any{"key1", struct{ foo string }{foo: "bar"}},
 			f:        logger.Error,
 		},
 		{
 			name:     "struct field quoted",
 			expected: "ERRO info key1=\"{foo:bar baz}\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", struct{ foo string }{foo: "bar baz"}},
+			kvs:      []any{"key1", struct{ foo string }{foo: "bar baz"}},
 			f:        logger.Error,
 		},
 		{
 			name:     "slice of strings",
 			expected: "ERRO info key1=\"[foo bar]\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", []string{"foo", "bar"}},
+			kvs:      []any{"key1", []string{"foo", "bar"}},
 			f:        logger.Error,
 		},
 		{
 			name:     "slice of structs",
 			expected: "ERRO info key1=\"[{foo:bar} {foo:baz}]\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", []struct{ foo string }{{foo: "bar"}, {foo: "baz"}}},
+			kvs:      []any{"key1", []struct{ foo string }{{foo: "bar"}, {foo: "baz"}}},
 			f:        logger.Error,
 		},
 		{
 			name:     "slice of errors",
 			expected: "ERRO info key1=\"[error value1 error value2]\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", []error{errors.New("error value1"), errors.New("error value2")}},
+			kvs:      []any{"key1", []error{errors.New("error value1"), errors.New("error value2")}},
 			f:        logger.Error,
 		},
 		{
 			name:     "map of strings",
 			expected: "ERRO info key1=\"map[baz:qux foo:bar]\"\n",
 			msg:      "info",
-			kvs:      []interface{}{"key1", map[string]string{"foo": "bar", "baz": "qux"}},
+			kvs:      []any{"key1", map[string]string{"foo": "bar", "baz": "qux"}},
 			f:        logger.Error,
 		},
 	}
@@ -255,8 +255,8 @@ func TestTextValueStyles(t *testing.T) {
 		name     string
 		expected string
 		msg      string
-		kvs      []interface{}
-		f        func(msg interface{}, kvs ...interface{})
+		kvs      []any
+		f        func(msg any, kvs ...any)
 	}{
 		{
 			name:     "simple message",
@@ -281,7 +281,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key2"), st.Separator.Render(separator), st.Value.Render("val2"),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", "val1", "key2", "val2"},
+			kvs: []any{"key1", "val1", "key2", "val2"},
 			f:   logger.Info,
 		},
 		{
@@ -294,7 +294,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Separator.Render(indentSeparator), st.Value.Render("val2"),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", "val1\nval2"},
+			kvs: []any{"key1", "val1\nval2"},
 			f:   logger.Error,
 		},
 		{
@@ -306,7 +306,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key2"), st.Separator.Render(separator), st.Value.Render("val2"),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", "val1", "key2", "val2"},
+			kvs: []any{"key1", "val1", "key2", "val2"},
 			f:   logger.Error,
 		},
 		{
@@ -319,7 +319,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key3"), st.Separator.Render(separator), st.Values["key3"].Render(`"missing value"`),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", "val1", "key2", "val2", "key3"},
+			kvs: []any{"key1", "val1", "key2", "val2", "key3"},
 			f:   logger.Error,
 		},
 		{
@@ -330,7 +330,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key1"), st.Separator.Render(separator), st.Value.Render(`"error value"`),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", errors.New("error value")},
+			kvs: []any{"key1", errors.New("error value")},
 			f:   logger.Error,
 		},
 		{
@@ -341,7 +341,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key1"), st.Separator.Render(separator), st.Value.Render("{foo:bar}"),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", struct{ foo string }{foo: "bar"}},
+			kvs: []any{"key1", struct{ foo string }{foo: "bar"}},
 			f:   logger.Info,
 		},
 		{
@@ -352,7 +352,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key1"), st.Separator.Render(separator), st.Value.Render(`"{foo:bar baz}"`),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", struct{ foo string }{foo: "bar baz"}},
+			kvs: []any{"key1", struct{ foo string }{foo: "bar baz"}},
 			f:   logger.Info,
 		},
 		{
@@ -363,7 +363,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key1"), st.Separator.Render(separator), st.Value.Render(`"[foo bar]"`),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", []string{"foo", "bar"}},
+			kvs: []any{"key1", []string{"foo", "bar"}},
 			f:   logger.Error,
 		},
 		{
@@ -374,7 +374,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key1"), st.Separator.Render(separator), st.Value.Render(`"[{foo:bar} {foo:baz}]"`),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", []struct{ foo string }{{foo: "bar"}, {foo: "baz"}}},
+			kvs: []any{"key1", []struct{ foo string }{{foo: "bar"}, {foo: "baz"}}},
 			f:   logger.Error,
 		},
 		{
@@ -385,7 +385,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key1"), st.Separator.Render(separator), st.Value.Render(`"[error value1 error value2]"`),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", []error{errors.New("error value1"), errors.New("error value2")}},
+			kvs: []any{"key1", []error{errors.New("error value1"), errors.New("error value2")}},
 			f:   logger.Error,
 		},
 		{
@@ -396,7 +396,7 @@ func TestTextValueStyles(t *testing.T) {
 				st.Key.Render("key1"), st.Separator.Render(separator), st.Value.Render(`"map[baz:qux foo:bar]"`),
 			),
 			msg: "info",
-			kvs: []interface{}{"key1", map[string]string{"foo": "bar", "baz": "qux"}},
+			kvs: []any{"key1", map[string]string{"foo": "bar", "baz": "qux"}},
 			f:   logger.Error,
 		},
 	}


### PR DESCRIPTION
### Describe your changes

This pr is a simple update.  Changes `interface{}` type references to `any`.   I noticed the language server gives a warning about `interface{} can be replaced by any`.  The `any` keyword was introduced in go 1.18 and this project uses 1.19 and above.  using `any` is the idiomatic way in modern go so I figured Id make the change.

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
