### PR TITLE
fix: data race in handle() when logging concurrently

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -81,6 +81,9 @@ func (l *Logger) Log(level Level, msg any, keyvals ...any) {
 }
 
 func (l *Logger) handle(level Level, ts time.Time, frames []runtime.Frame, msg any, keyvals ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	var kvs []any
 	if l.reportTimestamp && !ts.IsZero() {
 		kvs = append(kvs, TimestampKey, ts)
@@ -121,8 +124,6 @@ func (l *Logger) handle(level Level, ts time.Time, frames []runtime.Frame, msg a
 		kvs = append(kvs, ErrMissingValue)
 	}
 
-	l.mu.Lock()
-	defer l.mu.Unlock()
 	switch l.formatter {
 	case LogfmtFormatter:
 		l.logfmtFormatter(kvs...)


### PR DESCRIPTION
## Summary
- Move mutex lock to the beginning of `handle()` to protect all shared field reads
- Prevents sporadic panics when multiple goroutines log concurrently

## Root Cause
The lock was acquired only before calling the formatter, but `handle()` reads several shared fields before that:
- `l.styles.Levels[level]` — races with `SetStyles()`
- `l.prefix` — races with `WithPrefix()` on shared logger
- `l.fields` — races with `With()` on shared logger
- `l.reportTimestamp`, `l.reportCaller` — races with setters

This caused the panic in termenv's `xTermColor` reported in #176 — the unsynchronized style access corrupts color parsing mid-read.

## Fix
Move `l.mu.Lock()`/`defer l.mu.Unlock()` from line 124 to line 83 (start of `handle`). All shared reads now happen under the lock. Minimal change, maximum impact.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)