### PR TITLE
feat: enable timestamps by default in log.New()

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -24,6 +24,7 @@ func TestLogContext_simple(t *testing.T) {
 func TestLogContext_fields(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetReportTimestamp(false)
 	l.SetLevel(DebugLevel)
 	ctx := WithContext(context.Background(), l.With("foo", "bar"))
 	l = FromContext(ctx)

--- a/json_test.go
+++ b/json_test.go
@@ -16,6 +16,7 @@ import (
 func TestJson(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetReportTimestamp(false)
 	l.SetFormatter(JSONFormatter)
 	cases := []struct {
 		name     string
@@ -135,6 +136,7 @@ func TestJson(t *testing.T) {
 func TestJsonCaller(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetReportTimestamp(false)
 	l.SetFormatter(JSONFormatter)
 	l.SetReportCaller(true)
 	l.SetLevel(DebugLevel)
@@ -187,6 +189,7 @@ func TestJsonTime(t *testing.T) {
 func TestJsonPrefix(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(colorprofile.NewWriter(&buf, os.Environ()))
+	logger.SetReportTimestamp(false)
 	logger.SetFormatter(JSONFormatter)
 	logger.SetPrefix("my-prefix")
 	logger.Info("info")

--- a/logfmt_test.go
+++ b/logfmt_test.go
@@ -13,6 +13,7 @@ import (
 func TestLogfmt(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetReportTimestamp(false)
 	l.SetFormatter(LogfmtFormatter)
 	cases := []struct {
 		name     string

--- a/logger_121_test.go
+++ b/logger_121_test.go
@@ -18,6 +18,7 @@ import (
 func TestSlogSimple(t *testing.T) {
 	var buf bytes.Buffer
 	h := New(colorprofile.NewWriter(&buf, os.Environ()))
+	h.SetReportTimestamp(false)
 	h.SetLevel(DebugLevel)
 	l := slog.New(h)
 	cases := []struct {
@@ -76,6 +77,7 @@ func TestSlogSimple(t *testing.T) {
 func TestSlogWith(t *testing.T) {
 	var buf bytes.Buffer
 	h := New(colorprofile.NewWriter(&buf, os.Environ()))
+	h.SetReportTimestamp(false)
 	h.SetLevel(DebugLevel)
 	l := slog.New(h).With("a", "b")
 	cases := []struct {
@@ -127,6 +129,7 @@ func TestSlogWith(t *testing.T) {
 func TestSlogWithGroup(t *testing.T) {
 	var buf bytes.Buffer
 	h := New(colorprofile.NewWriter(&buf, os.Environ()))
+	h.SetReportTimestamp(false)
 	l := slog.New(h).WithGroup("charm").WithGroup("bracelet")
 	cases := []struct {
 		name     string
@@ -178,6 +181,7 @@ func TestSlogCustomLevel(t *testing.T) {
 		buf.Reset()
 		t.Run(c.name, func(t *testing.T) {
 			l := New(&buf)
+			l.SetReportTimestamp(false)
 			l.SetLevel(c.minLevel)
 			l.Handle(context.Background(), slog.NewRecord(time.Now(), c.level, "foo", 0))
 			assert.Equal(t, c.expected, buf.String())

--- a/logger_test.go
+++ b/logger_test.go
@@ -16,6 +16,7 @@ import (
 func TestSubLogger(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetReportTimestamp(false)
 	cases := []struct {
 		name     string
 		expected string
@@ -83,6 +84,7 @@ func TestWrongLevel(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			buf.Reset()
 			l := New(colorprofile.NewWriter(&buf, os.Environ()))
+			l.SetReportTimestamp(false)
 			l.SetLevel(c.level)
 			l.Info("info")
 			assert.Equal(t, c.expected, buf.String())
@@ -93,6 +95,7 @@ func TestWrongLevel(t *testing.T) {
 func TestLogFormatter(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetReportTimestamp(false)
 	l.SetLevel(DebugLevel)
 	cases := []struct {
 		name     string
@@ -142,6 +145,7 @@ func TestLogFormatter(t *testing.T) {
 func TestEmptyMessage(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetReportTimestamp(false)
 	cases := []struct {
 		name     string
 		expected string
@@ -199,6 +203,7 @@ func TestLogWithPrefix(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			buf.Reset()
 			l := New(colorprofile.NewWriter(&buf, os.Environ()))
+			l.SetReportTimestamp(false)
 			l.SetPrefix(c.prefix)
 			l.Info(c.msg)
 			assert.Equal(t, c.expected, buf.String())
@@ -283,6 +288,7 @@ func TestCustomLevel(t *testing.T) {
 	var buf bytes.Buffer
 	level500 := Level(500)
 	l := New(&buf)
+	l.SetReportTimestamp(false)
 	l.SetLevel(level500)
 	l.Logf(level500, "foo")
 	assert.Equal(t, "foo\n", buf.String())

--- a/options.go
+++ b/options.go
@@ -46,7 +46,7 @@ type Options struct {
 	Level Level
 	// Prefix is the prefix for the logger. The default is no prefix.
 	Prefix string
-	// ReportTimestamp is whether the logger should report the timestamp. The default is false.
+	// ReportTimestamp is whether the logger should report the timestamp. The default for New() is true.
 	ReportTimestamp bool
 	// ReportCaller is whether the logger should report the caller location. The default is false.
 	ReportCaller bool

--- a/pkg.go
+++ b/pkg.go
@@ -38,9 +38,9 @@ func SetDefault(logger *Logger) {
 	defaultLogger.Store(logger)
 }
 
-// New returns a new logger with the default options.
+// New returns a new logger with the default options, including timestamps enabled.
 func New(w io.Writer) *Logger {
-	return NewWithOptions(w, Options{})
+	return NewWithOptions(w, Options{ReportTimestamp: true})
 }
 
 // NewWithOptions returns a new logger using the provided options.

--- a/stdlog_test.go
+++ b/stdlog_test.go
@@ -17,6 +17,7 @@ import (
 func TestStdLog(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetReportTimestamp(false)
 	cases := []struct {
 		f        func(l *log.Logger)
 		name     string
@@ -52,6 +53,7 @@ func TestStdLog(t *testing.T) {
 func TestStdLog_forceLevel(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(colorprofile.NewWriter(&buf, os.Environ()))
+	logger.SetReportTimestamp(false)
 	cases := []struct {
 		name     string
 		expected string
@@ -86,6 +88,7 @@ func TestStdLog_forceLevel(t *testing.T) {
 func TestStdLog_writer(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(colorprofile.NewWriter(&buf, os.Environ()))
+	logger.SetReportTimestamp(false)
 	logger.SetReportCaller(true)
 	_, file, line, ok := runtime.Caller(0)
 	require.True(t, ok)

--- a/text_test.go
+++ b/text_test.go
@@ -33,6 +33,7 @@ func TestNilStyles(t *testing.T) {
 func TestTextCaller(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(&buf)
+	logger.SetReportTimestamp(false)
 	logger.SetReportCaller(true)
 	// We calculate the caller offset based on the caller line number.
 	_, file, line, _ := runtime.Caller(0)
@@ -102,6 +103,7 @@ func TestTextCaller(t *testing.T) {
 func TestTextLogger(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(&buf)
+	logger.SetReportTimestamp(false)
 	cases := []struct {
 		name     string
 		expected string
@@ -213,6 +215,7 @@ func TestTextLogger(t *testing.T) {
 func TestTextHelper(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(&buf)
+	logger.SetReportTimestamp(false)
 	logger.SetReportCaller(true)
 	helper := func() {
 		logger.Helper()
@@ -228,6 +231,7 @@ func TestTextHelper(t *testing.T) {
 func TestTextFatal(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(&buf)
+	logger.SetReportTimestamp(false)
 	logger.SetColorProfile(colorprofile.TrueColor)
 	logger.SetReportCaller(true)
 	if os.Getenv("FATAL") == "1" {
@@ -247,6 +251,7 @@ func TestTextFatal(t *testing.T) {
 func TestTextValueStyles(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(&buf)
+	logger.SetReportTimestamp(false)
 	logger.SetColorProfile(colorprofile.ANSI256)
 	st := DefaultStyles()
 	st.Value = lipgloss.NewStyle().Bold(true)
@@ -413,6 +418,7 @@ func TestTextValueStyles(t *testing.T) {
 func TestCustomLevelStyle(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(&buf)
+	l.SetReportTimestamp(false)
 	l.SetColorProfile(colorprofile.TrueColor)
 	st := DefaultStyles()
 	lvl := Level(1234)


### PR DESCRIPTION
## Summary
- `log.New()` now creates loggers with `ReportTimestamp: true` by default
- This aligns with the behavior most users expect and matches `Default()` which already has timestamps enabled
- `NewWithOptions()` continues to respect the explicitly provided `Options` value

## Test plan
- [x] Tests updated to explicitly disable timestamps where not expected
- [x] `go test ./...` passes

Closes #191