### PR TITLE
feat: add MultilineFields option for separate-line attributes

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -39,6 +39,7 @@ type Logger struct {
 
 	reportCaller    bool
 	reportTimestamp bool
+	multilineFields bool
 
 	fields []any
 
@@ -222,6 +223,13 @@ func (l *Logger) SetReportTimestamp(report bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.reportTimestamp = report
+}
+
+// SetMultilineFields sets whether key-value fields should be printed on separate lines.
+func (l *Logger) SetMultilineFields(multiline bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.multilineFields = multiline
 }
 
 // SetReportCaller sets whether the caller location should be reported.

--- a/options.go
+++ b/options.go
@@ -54,6 +54,8 @@ type Options struct {
 	CallerFormatter CallerFormatter
 	// CallerOffset is the caller format for the logger. The default is 0.
 	CallerOffset int
+	// MultilineFields prints each key-value pair on its own line. The default is false.
+	MultilineFields bool
 	// Fields is the fields for the logger. The default is no fields.
 	Fields []any
 	// Formatter is the formatter for the logger. The default is TextFormatter.

--- a/pkg.go
+++ b/pkg.go
@@ -52,6 +52,7 @@ func NewWithOptions(w io.Writer, o Options) *Logger {
 		level:           int64(o.Level),
 		reportTimestamp: o.ReportTimestamp,
 		reportCaller:    o.ReportCaller,
+		multilineFields: o.MultilineFields,
 		prefix:          o.Prefix,
 		timeFunc:        o.TimeFunction,
 		timeFormat:      o.TimeFormat,
@@ -85,6 +86,11 @@ func NewWithOptions(w io.Writer, o Options) *Logger {
 // SetReportTimestamp sets whether to report timestamp for the default logger.
 func SetReportTimestamp(report bool) {
 	Default().SetReportTimestamp(report)
+}
+
+// SetMultilineFields sets whether key-value fields should be printed on separate lines for the default logger.
+func SetMultilineFields(multiline bool) {
+	Default().SetMultilineFields(multiline)
 }
 
 // SetReportCaller sets whether to report caller location for the default logger.

--- a/text.go
+++ b/text.go
@@ -239,14 +239,24 @@ func (l *Logger) textFormatter(keyvals ...any) {
 				key = st.Key.Render(key)
 			}
 
-			// Values may contain multiple lines, and that format
-			// is preserved, with each line prefixed with a "  | "
-			// to show it's part of a collection of lines.
-			//
-			// Values may also need quoting, if not all the runes
-			// in the value string are "normal", like if they
-			// contain ANSI escape sequences.
-			if strings.Contains(val, "\n") {
+			// Quando multilineFields esta ativo, cada par chave-valor e impresso em linha separada
+			if l.multilineFields {
+				l.b.WriteString("\n  ")
+				l.b.WriteString(key)
+				l.b.WriteString(sep)
+				if !raw && needsQuoting(val) {
+					l.b.WriteString(valueStyle.Render(fmt.Sprintf(`"%s"`,
+						escapeStringForOutput(val, true))))
+				} else if strings.Contains(val, "\n") {
+					l.b.WriteString("\n")
+					l.writeIndent(&l.b, val, indentSep, moreKeys, actualKey)
+				} else {
+					l.b.WriteString(valueStyle.Render(val))
+				}
+			} else if strings.Contains(val, "\n") {
+				// Values may contain multiple lines, and that format
+				// is preserved, with each line prefixed with a "  | "
+				// to show it's part of a collection of lines.
 				l.b.WriteString("\n  ")
 				l.b.WriteString(key)
 				l.b.WriteString(sep + "\n")

--- a/text_test.go
+++ b/text_test.go
@@ -410,6 +410,15 @@ func TestTextValueStyles(t *testing.T) {
 	}
 }
 
+func TestMultilineFields(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(&buf)
+	l.SetReportTimestamp(false)
+	l.SetMultilineFields(true)
+	l.Info("hello", "key1", "val1", "key2", "val2")
+	assert.Equal(t, "INFO hello\n  key1=val1\n  key2=val2\n", buf.String())
+}
+
 func TestCustomLevelStyle(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(&buf)


### PR DESCRIPTION
## Summary
- Adds `SetMultilineFields(bool)` to Logger and `MultilineFields` to Options
- When enabled, each key-value pair is printed on its own line, indented with two spaces
- Example output:
  ```
  INFO hello
    key1=val1
    key2=val2
  ```
- Also adds package-level `SetMultilineFields()` for the default logger

## Test plan
- [x] Added `TestMultilineFields`
- [x] `go test ./...` passes

Closes #178