### PR TITLE
fix: document and address io.Writer concurrency gotcha

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,34 @@
 // Package log provides a simple and flexible logger with support for
 // structured logging, log levels, and customizable output formats.
+//
+// # Concurrency
+//
+// A single Logger instance is safe for concurrent use from multiple
+// goroutines. However, when multiple Logger instances share the same
+// io.Writer, the writer itself must be safe for concurrent use.
+// Use [NewSyncWriter] to wrap a non-thread-safe writer.
 package log
+
+import (
+	"io"
+	"sync"
+)
+
+// SyncWriter wraps an io.Writer with a mutex to make it safe for concurrent use.
+type SyncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewSyncWriter returns a new SyncWriter that serializes writes to w.
+// Use this when sharing a single writer between multiple Logger instances.
+func NewSyncWriter(w io.Writer) *SyncWriter {
+	return &SyncWriter{w: w}
+}
+
+// Write implements io.Writer.
+func (sw *SyncWriter) Write(p []byte) (n int, err error) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.w.Write(p)
+}

--- a/logger.go
+++ b/logger.go
@@ -274,6 +274,12 @@ func (l *Logger) SetTimeFunction(f TimeFunction) {
 }
 
 // SetOutput sets the output destination.
+//
+// Note: The logger uses an internal mutex to serialize writes, so a single
+// logger instance is safe for concurrent use. However, if multiple loggers
+// share the same io.Writer, or if application code writes to the same writer
+// concurrently, the writer itself must be safe for concurrent use.
+// Use NewSyncWriter to wrap a non-thread-safe writer.
 func (l *Logger) SetOutput(w io.Writer) {
 	l.mu.Lock()
 	defer l.mu.Unlock()


### PR DESCRIPTION
## Summary
- Adds `SyncWriter` and `NewSyncWriter()` to wrap non-thread-safe writers for safe concurrent use across multiple Logger instances
- Documents the concurrency model in `SetOutput()` and in the package doc comment
- A single Logger is already safe for concurrent use (protected by internal mutex), but sharing one io.Writer between multiple Loggers requires the writer to be thread-safe

## Test plan
- [x] `go test ./...` passes
- [x] `go test -race ./...` passes

Closes #177