### PR TITLE
feat: add TraceLevel for verbose logging below debug

### DIFF
--- a/level.go
+++ b/level.go
@@ -11,6 +11,8 @@ import (
 type Level int
 
 const (
+	// TraceLevel is the trace level. More verbose than debug.
+	TraceLevel Level = -8
 	// DebugLevel is the debug level.
 	DebugLevel Level = -4
 	// InfoLevel is the info level.
@@ -28,6 +30,8 @@ const (
 // String returns the string representation of the level.
 func (l Level) String() string {
 	switch l {
+	case TraceLevel:
+		return "trace"
 	case DebugLevel:
 		return "debug"
 	case InfoLevel:
@@ -49,6 +53,8 @@ var ErrInvalidLevel = errors.New("invalid level")
 // ParseLevel converts level in string to Level type. Default level is InfoLevel.
 func ParseLevel(level string) (Level, error) {
 	switch strings.ToLower(level) {
+	case TraceLevel.String():
+		return TraceLevel, nil
 	case DebugLevel.String():
 		return DebugLevel, nil
 	case InfoLevel.String():

--- a/logger.go
+++ b/logger.go
@@ -351,6 +351,11 @@ func (l *Logger) WithPrefix(prefix string) *Logger {
 }
 
 // Debug prints a debug message.
+// Trace prints a trace message. More verbose than debug.
+func (l *Logger) Trace(msg any, keyvals ...any) {
+	l.Log(TraceLevel, msg, keyvals...)
+}
+
 func (l *Logger) Debug(msg any, keyvals ...any) {
 	l.Log(DebugLevel, msg, keyvals...)
 }


### PR DESCRIPTION
## Summary
- Add `TraceLevel` (-8) for fine-grained logging below `DebugLevel`

## Problem
Some applications need more verbose logging than `DebugLevel` for tracing execution paths, function calls, or protocol details. There was no level below debug.

## Solution
- New `TraceLevel` constant at `-8` (below `DebugLevel` at `-4`)
- New `Trace(msg, keyvals...)` method on `Logger`
- `ParseLevel("trace")` support

```go
logger.SetLevel(log.TraceLevel)
logger.Trace("entering function", "name", "handleRequest")
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Backwards compatible — existing levels unaffected

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)