### PR TITLE
fix: print user keys that shadow reserved key names as regular fields

### DIFF
--- a/json.go
+++ b/json.go
@@ -34,18 +34,26 @@ func (l *Logger) jsonFormatterRoot(jw *jsonWriter, key, value any) {
 	case TimestampKey:
 		if t, ok := value.(time.Time); ok {
 			jw.objectItem(TimestampKey, t.Format(l.timeFormat))
+		} else {
+			l.jsonFormatterItem(jw, key, value)
 		}
 	case LevelKey:
 		if level, ok := value.(Level); ok {
 			jw.objectItem(LevelKey, level.String())
+		} else {
+			l.jsonFormatterItem(jw, key, value)
 		}
 	case CallerKey:
 		if caller, ok := value.(string); ok {
 			jw.objectItem(CallerKey, caller)
+		} else {
+			l.jsonFormatterItem(jw, key, value)
 		}
 	case PrefixKey:
 		if prefix, ok := value.(string); ok {
 			jw.objectItem(PrefixKey, prefix)
+		} else {
+			l.jsonFormatterItem(jw, key, value)
 		}
 	case MessageKey:
 		if msg := value; msg != nil {

--- a/text.go
+++ b/text.go
@@ -179,6 +179,8 @@ func (l *Logger) textFormatter(keyvals ...any) {
 				ts = st.Timestamp.Render(ts)
 				writeSpace(&l.b, firstKey)
 				l.b.WriteString(ts)
+			} else {
+				l.writeKVPair(firstKey, moreKeys, keyvals[i], keyvals[i+1])
 			}
 		case LevelKey:
 			if level, ok := keyvals[i+1].(Level); ok {
@@ -193,6 +195,8 @@ func (l *Logger) textFormatter(keyvals ...any) {
 					writeSpace(&l.b, firstKey)
 					l.b.WriteString(lvl)
 				}
+			} else {
+				l.writeKVPair(firstKey, moreKeys, keyvals[i], keyvals[i+1])
 			}
 		case CallerKey:
 			if caller, ok := keyvals[i+1].(string); ok {
@@ -200,12 +204,16 @@ func (l *Logger) textFormatter(keyvals ...any) {
 				caller = st.Caller.Render(caller)
 				writeSpace(&l.b, firstKey)
 				l.b.WriteString(caller)
+			} else {
+				l.writeKVPair(firstKey, moreKeys, keyvals[i], keyvals[i+1])
 			}
 		case PrefixKey:
 			if prefix, ok := keyvals[i+1].(string); ok {
 				prefix = st.Prefix.Render(prefix + ":")
 				writeSpace(&l.b, firstKey)
 				l.b.WriteString(prefix)
+			} else {
+				l.writeKVPair(firstKey, moreKeys, keyvals[i], keyvals[i+1])
 			}
 		case MessageKey:
 			if msg := keyvals[i+1]; msg != nil {
@@ -215,58 +223,66 @@ func (l *Logger) textFormatter(keyvals ...any) {
 				l.b.WriteString(m)
 			}
 		default:
-			sep := separator
-			indentSep := indentSeparator
-			sep = st.Separator.Render(sep)
-			indentSep = st.Separator.Render(indentSep)
-			key := fmt.Sprint(keyvals[i])
-			val := fmt.Sprintf("%+v", keyvals[i+1])
-			raw := val == ""
-			if raw {
-				val = `""`
-			}
-			if key == "" {
-				continue
-			}
-			actualKey := key
-			valueStyle := st.Value
-			if vs, ok := st.Values[actualKey]; ok {
-				valueStyle = vs
-			}
-			if keyStyle, ok := st.Keys[key]; ok {
-				key = keyStyle.Render(key)
-			} else {
-				key = st.Key.Render(key)
-			}
-
-			// Values may contain multiple lines, and that format
-			// is preserved, with each line prefixed with a "  | "
-			// to show it's part of a collection of lines.
-			//
-			// Values may also need quoting, if not all the runes
-			// in the value string are "normal", like if they
-			// contain ANSI escape sequences.
-			if strings.Contains(val, "\n") {
-				l.b.WriteString("\n  ")
-				l.b.WriteString(key)
-				l.b.WriteString(sep + "\n")
-				l.writeIndent(&l.b, val, indentSep, moreKeys, actualKey)
-			} else if !raw && needsQuoting(val) {
-				writeSpace(&l.b, firstKey)
-				l.b.WriteString(key)
-				l.b.WriteString(sep)
-				l.b.WriteString(valueStyle.Render(fmt.Sprintf(`"%s"`,
-					escapeStringForOutput(val, true))))
-			} else {
-				val = valueStyle.Render(val)
-				writeSpace(&l.b, firstKey)
-				l.b.WriteString(key)
-				l.b.WriteString(sep)
-				l.b.WriteString(val)
-			}
+			l.writeKVPair(firstKey, moreKeys, keyvals[i], keyvals[i+1])
 		}
 	}
 
 	// Add a newline to the end of the log message.
 	l.b.WriteByte('\n')
+}
+
+// writeKVPair writes a key-value pair using the default text formatting.
+// Used by textFormatter for both the default case and as a fallback when a
+// reserved key name is present but the value's type does not match the
+// expected built-in type (e.g. a user-supplied key named "time" with a
+// non-time.Time value).
+func (l *Logger) writeKVPair(firstKey, moreKeys bool, k, v any) {
+	st := l.styles
+	sep := st.Separator.Render(separator)
+	indentSep := st.Separator.Render(indentSeparator)
+	key := fmt.Sprint(k)
+	val := fmt.Sprintf("%+v", v)
+	raw := val == ""
+	if raw {
+		val = `""`
+	}
+	if key == "" {
+		return
+	}
+	actualKey := key
+	valueStyle := st.Value
+	if vs, ok := st.Values[actualKey]; ok {
+		valueStyle = vs
+	}
+	if keyStyle, ok := st.Keys[key]; ok {
+		key = keyStyle.Render(key)
+	} else {
+		key = st.Key.Render(key)
+	}
+
+	// Values may contain multiple lines, and that format
+	// is preserved, with each line prefixed with a "  | "
+	// to show it's part of a collection of lines.
+	//
+	// Values may also need quoting, if not all the runes
+	// in the value string are "normal", like if they
+	// contain ANSI escape sequences.
+	if strings.Contains(val, "\n") {
+		l.b.WriteString("\n  ")
+		l.b.WriteString(key)
+		l.b.WriteString(sep + "\n")
+		l.writeIndent(&l.b, val, indentSep, moreKeys, actualKey)
+	} else if !raw && needsQuoting(val) {
+		writeSpace(&l.b, firstKey)
+		l.b.WriteString(key)
+		l.b.WriteString(sep)
+		l.b.WriteString(valueStyle.Render(fmt.Sprintf(`"%s"`,
+			escapeStringForOutput(val, true))))
+	} else {
+		val = valueStyle.Render(val)
+		writeSpace(&l.b, firstKey)
+		l.b.WriteString(key)
+		l.b.WriteString(sep)
+		l.b.WriteString(val)
+	}
 }

--- a/text_test.go
+++ b/text_test.go
@@ -410,6 +410,19 @@ func TestTextValueStyles(t *testing.T) {
 	}
 }
 
+func TestReservedKeyNonBuiltinValue(t *testing.T) {
+	// When a user-provided key has the same name as a built-in key (e.g.
+	// "time") but holds a non-matching value type, the key-value pair should
+	// be printed as a regular field instead of being silently dropped.
+	var buf bytes.Buffer
+	l := New(&buf)
+	l.SetReportTimestamp(false)
+	l.Info("msg", "time", "0", "other", "1", "time", "2")
+	assert.Contains(t, buf.String(), "time=0")
+	assert.Contains(t, buf.String(), "other=1")
+	assert.Contains(t, buf.String(), "time=2")
+}
+
 func TestCustomLevelStyle(t *testing.T) {
 	var buf bytes.Buffer
 	l := New(&buf)


### PR DESCRIPTION
## Problem

When using `gum log --structured`, passing a key named `time` causes that key-value pair to be silently dropped in the text and JSON formatters.

Reproduction (from [charmbracelet/gum#967](https://github.com/charmbracelet/gum/issues/967)):

```sh
gum log --structured "Test log message" time 0 normal_var 1 time 2
# prints: Test log message normal_var=1
# expected: Test log message time=0 normal_var=1 time=2
```

The same silent-drop affects any user key whose name matches a built-in key (`time`, `level`, `caller`, `prefix`) when the value's type does not match the expected built-in type.

## Root cause

In `textFormatter` and `jsonFormatterRoot`, each built-in key case does a type assertion and renders the value in a special style. When the assertion fails, the code falls through with no output. The `logfmtFormatter` already handles this correctly by always encoding the key-value regardless of the type assertion result.

## Fix

- **text.go**: Extracts the default KV-writing logic into a `writeKVPair` helper and calls it as the `else` branch for `TimestampKey`, `LevelKey`, `CallerKey`, and `PrefixKey`.
- **json.go**: Adds an `else` branch calling the existing `jsonFormatterItem` helper for the same set of keys.
- **text_test.go**: Adds `TestReservedKeyNonBuiltinValue` to cover the reported scenario.

`MessageKey` is intentionally left unchanged — a user passing `msg` as a structured key would produce a duplicate message field, which is a separate discussion.