### PR TITLE
Share level pointer so child loggers inherit parent level changes

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -29,7 +29,7 @@ type Logger struct {
 
 	isDiscard uint32
 
-	level           int64
+	level           *int64
 	prefix          string
 	timeFunc        TimeFunction
 	timeFormat      string
@@ -58,7 +58,7 @@ func (l *Logger) Log(level Level, msg any, keyvals ...any) {
 	}
 
 	// check if the level is allowed
-	if atomic.LoadInt64(&l.level) > int64(level) {
+	if atomic.LoadInt64(l.level) > int64(level) {
 		return
 	}
 
@@ -233,16 +233,12 @@ func (l *Logger) SetReportCaller(report bool) {
 
 // GetLevel returns the current level.
 func (l *Logger) GetLevel() Level {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	return Level(l.level)
+	return Level(atomic.LoadInt64(l.level))
 }
 
 // SetLevel sets the current level.
 func (l *Logger) SetLevel(level Level) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	atomic.StoreInt64(&l.level, int64(level))
+	atomic.StoreInt64(l.level, int64(level))
 }
 
 // GetPrefix returns the current prefix.

--- a/logger_121.go
+++ b/logger_121.go
@@ -24,7 +24,7 @@ const slogKindGroup = slog.KindGroup
 //
 // Implements slog.Handler.
 func (l *Logger) Enabled(_ context.Context, level slog.Level) bool {
-	return atomic.LoadInt64(&l.level) <= int64(level)
+	return atomic.LoadInt64(l.level) <= int64(level)
 }
 
 // Handle handles the Record. It will only be called if Enabled returns true.

--- a/logger_no121.go
+++ b/logger_no121.go
@@ -25,7 +25,7 @@ const slogKindGroup = slog.KindGroup
 //
 // Implements slog.Handler.
 func (l *Logger) Enabled(_ context.Context, level slog.Level) bool {
-	return atomic.LoadInt64(&l.level) <= int64(level)
+	return atomic.LoadInt64(l.level) <= int64(level)
 }
 
 // Handle handles the Record. It will only be called if Enabled returns true.

--- a/logger_test.go
+++ b/logger_test.go
@@ -279,6 +279,24 @@ func TestRace(t *testing.T) {
 	}
 }
 
+func TestWithInheritsParentLevel(t *testing.T) {
+	var buf bytes.Buffer
+	parent := New(&buf)
+	parent.SetLevel(InfoLevel)
+
+	child := parent.With("key", "value")
+
+	// child should see the parent's level change
+	parent.SetLevel(DebugLevel)
+	child.Debug("should appear")
+	assert.NotEmpty(t, buf.String(), "child logger should inherit parent's level change")
+
+	buf.Reset()
+	parent.SetLevel(ErrorLevel)
+	child.Info("should not appear")
+	assert.Empty(t, buf.String(), "child logger should not log below parent's updated level")
+}
+
 func TestCustomLevel(t *testing.T) {
 	var buf bytes.Buffer
 	level500 := Level(500)

--- a/pkg.go
+++ b/pkg.go
@@ -45,11 +45,12 @@ func New(w io.Writer) *Logger {
 
 // NewWithOptions returns a new logger using the provided options.
 func NewWithOptions(w io.Writer, o Options) *Logger {
+	lvl := int64(o.Level)
 	l := &Logger{
 		b:               bytes.Buffer{},
 		mu:              &sync.RWMutex{},
 		helpers:         &sync.Map{},
-		level:           int64(o.Level),
+		level:           &lvl,
 		reportTimestamp: o.ReportTimestamp,
 		reportCaller:    o.ReportCaller,
 		prefix:          o.Prefix,
@@ -64,7 +65,7 @@ func NewWithOptions(w io.Writer, o Options) *Logger {
 	l.SetOutput(w)
 	// Detect color profile from the writer and environment.
 	l.SetColorProfile(colorprofile.Detect(w, os.Environ()))
-	l.SetLevel(Level(l.level))
+	l.SetLevel(o.Level)
 	l.SetStyles(DefaultStyles())
 
 	if l.callerFormatter == nil {


### PR DESCRIPTION
Fixes #184.

When `With()` copies the logger struct, the `level` field was copied by value, so the child got its own independent level. Calling `SetLevel` on the parent after creating a child had no effect on the child.

The fix is straightforward: change `level` from `int64` to `*int64`. Since parent and child now share the same pointer, a `SetLevel` call on either one is immediately visible to both. All the atomic reads/writes already go through `atomic.LoadInt64`/`atomic.StoreInt64`, they just don't need the address-of operator anymore. Also dropped the mutex from `GetLevel` and `SetLevel` since the atomics are sufficient.

Added a regression test in `logger_test.go` (`TestWithInheritsParentLevel`) that verifies the child sees the parent's level changes in both directions.

To test: run `go test -run TestWithInheritsParentLevel ./...`