### PR TITLE
fix: share mutex between a logger and its With() clones

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -335,7 +335,9 @@ func (l *Logger) With(keyvals ...any) *Logger {
 	st = *l.styles
 	l.mu.Unlock()
 	sl.b = bytes.Buffer{}
-	sl.mu = &sync.RWMutex{}
+	// Share the parent's mutex so concurrent writes from the parent and any
+	// clones serialize on the same underlying io.Writer. Matches log/slog's
+	// handler clone behavior; see charmbracelet/log#177.
 	sl.helpers = &sync.Map{}
 	sl.fields = append(make([]any, 0, len(l.fields)+len(keyvals)), l.fields...)
 	sl.fields = append(sl.fields, keyvals...)

--- a/logger_test.go
+++ b/logger_test.go
@@ -287,3 +287,21 @@ func TestCustomLevel(t *testing.T) {
 	l.Logf(level500, "foo")
 	assert.Equal(t, "foo\n", buf.String())
 }
+
+func TestWithSharesMutex(t *testing.T) {
+	// Regression test for #177. With() must share the parent logger's mutex
+	// with the cloned logger so that concurrent writes to the same output
+	// from the parent and any clones get serialized. log/slog's handler
+	// clone behaves the same way.
+	l := New(io.Discard)
+	sl := l.With("foo", "bar")
+	if l.mu != sl.mu {
+		t.Errorf("With() should share the parent's mutex, got distinct pointers (parent=%p, clone=%p)", l.mu, sl.mu)
+	}
+
+	// Two levels of cloning should still share the original mutex.
+	ssl := sl.With("baz", "qux")
+	if l.mu != ssl.mu {
+		t.Errorf("nested With() should still share the root mutex, got distinct pointers")
+	}
+}


### PR DESCRIPTION
Closes #177.

\`With()\` was constructing a fresh \`*sync.RWMutex\` for every cloned logger, so the parent and any clones each held their own lock. They all share the same output \`io.Writer\` though, so concurrent writes from a parent and a clone weren't actually serialized — exactly the gotcha \`log/slog\` avoids by sharing the handler mutex among clones (see [\`commonHandler.clone()\`](https://cs.opensource.google/go/go/+/refs/tags/go1.24.5:src/log/slog/handler.go;l=211)).

The fix is to drop the new-mutex line. The value copy of \`l\` on the line above already gives the clone the parent's mutex pointer, and the existing assignments of \`fields\`, \`helpers\`, and \`styles\` still get fresh copies, so behavior is unchanged otherwise.

## Test plan

\`\`\`
go test -race ./...
\`\`\`

Added \`TestWithSharesMutex\` asserting that one and two levels of \`With()\` produce loggers with the same \`mu\` pointer as the root. Existing \`TestLogWithRaceCondition\` and \`TestRace\` still pass with \`-race\`.