### PR TITLE
fix: don't drop user keyvals named like reserved keys

### DIFF
--- a/json.go
+++ b/json.go
@@ -30,30 +30,37 @@ func (l *Logger) jsonFormatter(keyvals ...any) {
 }
 
 func (l *Logger) jsonFormatterRoot(jw *jsonWriter, key, value any) {
+	// Reserved keys get their typed-value rendering. When a user passes one
+	// of the names with a different value type, fall back to the regular
+	// keyval path so the entry isn't silently dropped (see #166).
 	switch key {
 	case TimestampKey:
 		if t, ok := value.(time.Time); ok {
 			jw.objectItem(TimestampKey, t.Format(l.timeFormat))
+			return
 		}
 	case LevelKey:
 		if level, ok := value.(Level); ok {
 			jw.objectItem(LevelKey, level.String())
+			return
 		}
 	case CallerKey:
 		if caller, ok := value.(string); ok {
 			jw.objectItem(CallerKey, caller)
+			return
 		}
 	case PrefixKey:
 		if prefix, ok := value.(string); ok {
 			jw.objectItem(PrefixKey, prefix)
+			return
 		}
 	case MessageKey:
-		if msg := value; msg != nil {
-			jw.objectItem(MessageKey, fmt.Sprint(msg))
+		if value != nil {
+			jw.objectItem(MessageKey, fmt.Sprint(value))
+			return
 		}
-	default:
-		l.jsonFormatterItem(jw, key, value)
 	}
+	l.jsonFormatterItem(jw, key, value)
 }
 
 func (l *Logger) jsonFormatterItem(jw *jsonWriter, key, value any) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -287,3 +287,21 @@ func TestCustomLevel(t *testing.T) {
 	l.Logf(level500, "foo")
 	assert.Equal(t, "foo\n", buf.String())
 }
+
+func TestKeyvalNamedAsReservedKey(t *testing.T) {
+	// #166. A user-provided keyval whose key collides with a reserved name
+	// (level, ts, caller, prefix, msg) used to be silently dropped when the
+	// value wasn't the type the internal logger emits.
+	var buf bytes.Buffer
+	l := New(&buf)
+	l.SetReportTimestamp(false)
+	l.SetReportCaller(false)
+
+	l.Info("test", "level", "foo", "anything-else", "bar")
+	assert.Equal(t, "INFO test level=foo anything-else=bar\n", buf.String())
+
+	buf.Reset()
+	l.SetFormatter(JSONFormatter)
+	l.Info("test", "level", "foo", "anything-else", "bar")
+	assert.Equal(t, "{\"level\":\"info\",\"msg\":\"test\",\"level\":\"foo\",\"anything-else\":\"bar\"}\n", buf.String())
+}

--- a/text.go
+++ b/text.go
@@ -172,9 +172,16 @@ func (l *Logger) textFormatter(keyvals ...any) {
 		firstKey := i == 0
 		moreKeys := i < lenKeyvals-2
 
+		// Reserved keys (timestamp, level, caller, prefix, msg) get special
+		// rendering only when paired with the type the internal logger emits.
+		// When a user passes one of these names with a different value type
+		// (e.g. "level", "foo"), the keyval is silently dropped — see #166.
+		// Detect the mismatch up front and let the default branch render it.
+		reserved := false
 		switch keyvals[i] {
 		case TimestampKey:
 			if t, ok := keyvals[i+1].(time.Time); ok {
+				reserved = true
 				ts := t.Format(l.timeFormat)
 				ts = st.Timestamp.Render(ts)
 				writeSpace(&l.b, firstKey)
@@ -182,20 +189,19 @@ func (l *Logger) textFormatter(keyvals ...any) {
 			}
 		case LevelKey:
 			if level, ok := keyvals[i+1].(Level); ok {
-				var lvl string
+				reserved = true
 				lvlStyle, ok := st.Levels[level]
 				if !ok {
 					continue
 				}
-
-				lvl = lvlStyle.String()
-				if lvl != "" {
+				if lvl := lvlStyle.String(); lvl != "" {
 					writeSpace(&l.b, firstKey)
 					l.b.WriteString(lvl)
 				}
 			}
 		case CallerKey:
 			if caller, ok := keyvals[i+1].(string); ok {
+				reserved = true
 				caller = fmt.Sprintf("<%s>", caller)
 				caller = st.Caller.Render(caller)
 				writeSpace(&l.b, firstKey)
@@ -203,18 +209,24 @@ func (l *Logger) textFormatter(keyvals ...any) {
 			}
 		case PrefixKey:
 			if prefix, ok := keyvals[i+1].(string); ok {
+				reserved = true
 				prefix = st.Prefix.Render(prefix + ":")
 				writeSpace(&l.b, firstKey)
 				l.b.WriteString(prefix)
 			}
 		case MessageKey:
 			if msg := keyvals[i+1]; msg != nil {
+				reserved = true
 				m := fmt.Sprint(msg)
 				m = st.Message.Render(m)
 				writeSpace(&l.b, firstKey)
 				l.b.WriteString(m)
 			}
-		default:
+		}
+		if reserved {
+			continue
+		}
+		{
 			sep := separator
 			indentSep := indentSeparator
 			sep = st.Separator.Render(sep)


### PR DESCRIPTION
Closes #166.

When a user passed a keyval whose key matched one of the reserved names (\`level\`, \`ts\`, \`caller\`, \`prefix\`, \`msg\`) but with a value of a different type than the internal logger uses, the entry was silently dropped:

\`\`\`go
log.Info(\"test\", \"level\", \"foo\", \"anything-else\", \"bar\")
// before: INFO test anything-else=bar
// after:  INFO test level=foo anything-else=bar
\`\`\`

Both the text and JSON formatters had the same shape — \`case LevelKey:\` matched the key, the inner type assertion failed, and the switch fell off the end without writing anything or falling through to the default keyval rendering.

Now each special case only takes ownership of the entry when its type assertion succeeds; otherwise the default path renders it as a regular keyval.

## Test plan

\`\`\`
go test ./...
go test -race ./...
\`\`\`

Added \`TestKeyvalNamedAsReservedKey\` covering both text and JSON formatters with the case from the issue.