### PR TITLE
fix: apply specific value style

### DIFF
--- a/text.go
+++ b/text.go
@@ -40,7 +40,11 @@ func (l *Logger) writeIndent(w io.Writer, str string, indent string, newline boo
 
 		_, _ = w.Write([]byte(indent))
 		val := escapeStringForOutput(str[:nl], false)
-		val = st.Value.Render(val)
+		if valueStyle, ok := st.Values[key]; ok {
+			val = valueStyle.Render(val)
+		} else {
+			val = st.Value.Render(val)
+		}
 		_, _ = w.Write([]byte(val))
 		_, _ = w.Write([]byte{'\n'})
 		str = str[nl+1:]


### PR DESCRIPTION
..., if any, for all lines of a multiple lines value

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- ~~[ ] I have created a discussion that was approved by a maintainer (for new features).~~ (N/A)

Please, compare the provided example without and with the proposed fix.
```
package main

import (
	"os"
	"charm.land/lipgloss/v2"
	"charm.land/log/v2"
)

func main() {
	styles := log.DefaultStyles()
	styles.Values["foo"] = lipgloss.NewStyle().Foreground(lipgloss.Yellow)
	logger := log.New(os.Stdout)
	logger.SetStyles(styles)
	logger.Info("dummy", "foo", "line1\nline2")
}
```
