### PR TITLE
fix: loggers created with With() now inherit level changes on the parent

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -29,7 +29,7 @@ type Logger struct {
 
 	isDiscard uint32
 
-	level           int64
+	level           *int64
 	prefix          string
 	timeFunc        TimeFunction
 	timeFormat      string
@@ -58,7 +58,7 @@ func (l *Logger) Log(level Level, msg any, keyvals ...any) {
 	}
 
 	// check if the level is allowed
-	if atomic.LoadInt64(&l.level) > int64(level) {
+	if atomic.LoadInt64(l.level) > int64(level) {
 		return
 	}
 
@@ -233,16 +233,12 @@ func (l *Logger) SetReportCaller(report bool) {
 
 // GetLevel returns the current level.
 func (l *Logger) GetLevel() Level {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	return Level(l.level)
+	return Level(atomic.LoadInt64(l.level))
 }
 
 // SetLevel sets the current level.
 func (l *Logger) SetLevel(level Level) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	atomic.StoreInt64(&l.level, int64(level))
+	atomic.StoreInt64(l.level, int64(level))
 }
 
 // GetPrefix returns the current prefix.

--- a/logger_121.go
+++ b/logger_121.go
@@ -24,7 +24,7 @@ const slogKindGroup = slog.KindGroup
 //
 // Implements slog.Handler.
 func (l *Logger) Enabled(_ context.Context, level slog.Level) bool {
-	return atomic.LoadInt64(&l.level) <= int64(level)
+	return atomic.LoadInt64(l.level) <= int64(level)
 }
 
 // Handle handles the Record. It will only be called if Enabled returns true.

--- a/logger_no121.go
+++ b/logger_no121.go
@@ -25,7 +25,7 @@ const slogKindGroup = slog.KindGroup
 //
 // Implements slog.Handler.
 func (l *Logger) Enabled(_ context.Context, level slog.Level) bool {
-	return atomic.LoadInt64(&l.level) <= int64(level)
+	return atomic.LoadInt64(l.level) <= int64(level)
 }
 
 // Handle handles the Record. It will only be called if Enabled returns true.

--- a/logger_test.go
+++ b/logger_test.go
@@ -287,3 +287,18 @@ func TestCustomLevel(t *testing.T) {
 	l.Logf(level500, "foo")
 	assert.Equal(t, "foo\n", buf.String())
 }
+
+func TestWithInheritsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(colorprofile.NewWriter(&buf, os.Environ()))
+	l.SetLevel(InfoLevel)
+	l.SetReportTimestamp(false)
+	l.SetReportCaller(false)
+
+	wrapped := l.With("k", "v")
+
+	// Level raised on parent after wrapped logger created — child must see it.
+	l.SetLevel(DebugLevel)
+	wrapped.Debug("debug msg")
+	assert.Equal(t, "DEBU debug msg k=v\n", buf.String())
+}

--- a/pkg.go
+++ b/pkg.go
@@ -45,11 +45,12 @@ func New(w io.Writer) *Logger {
 
 // NewWithOptions returns a new logger using the provided options.
 func NewWithOptions(w io.Writer, o Options) *Logger {
+	lvl := int64(o.Level)
 	l := &Logger{
 		b:               bytes.Buffer{},
 		mu:              &sync.RWMutex{},
 		helpers:         &sync.Map{},
-		level:           int64(o.Level),
+		level:           &lvl,
 		reportTimestamp: o.ReportTimestamp,
 		reportCaller:    o.ReportCaller,
 		prefix:          o.Prefix,
@@ -64,7 +65,7 @@ func NewWithOptions(w io.Writer, o Options) *Logger {
 	l.SetOutput(w)
 	// Detect color profile from the writer and environment.
 	l.SetColorProfile(colorprofile.Detect(w, os.Environ()))
-	l.SetLevel(Level(l.level))
+	l.SetLevel(Level(*l.level))
 	l.SetStyles(DefaultStyles())
 
 	if l.callerFormatter == nil {


### PR DESCRIPTION
Fixes #184.

## Problem

`With()` creates a new `Logger` by shallow-copying the struct (`sl := *l`). Because `level` was an `int64` value field, the copy held an independent integer. Any subsequent `SetLevel` call on the parent had no effect on the child, and vice-versa.

## Fix

Change `level` from `int64` to `*int64`. `NewWithOptions` allocates a fresh `int64` for every root logger. `With()` copies the pointer, so the parent and all children derived from it share the same memory cell. A `SetLevel` call on any of them is immediately visible to all.

All atomic operations are updated to dereference the pointer (`atomic.LoadInt64(l.level)` / `atomic.StoreInt64(l.level, v)`), preserving thread-safety.