### PR TITLE
docs: fix README install path to charm.land/log/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ readable logging with batteries included.
 Use `go get` to download the dependency.
 
 ```bash
-go get github.com/charmbracelet/log@latest
+go get charm.land/log/v2@latest
 ```
 
 Then, `import` it in your Go files:
 
 ```go
-import "github.com/charmbracelet/log"
+import "charm.land/log/v2"
 ```
 
 The Charm logger comes with a global package-wise logger with timestamps turned


### PR DESCRIPTION
The module moved to `charm.land/log/v2` in #190, but the README Usage section still points at the old path. Following it installs the frozen v1.0.0 instead of v2:

- `go get github.com/charmbracelet/log@latest` resolves to v1.0.0 (last tag on that path)
- `go get charm.land/log/v2@latest` resolves to v2.0.0

Updated the `go get` command and the import to the v2 path. Verified a fresh module using the corrected lines builds against v2.0.0.